### PR TITLE
feat: remove first error default break chain

### DIFF
--- a/packages/fe-utils/common/__tests__/executor/impl/SyncExecutor.test.ts
+++ b/packages/fe-utils/common/__tests__/executor/impl/SyncExecutor.test.ts
@@ -581,7 +581,12 @@ describe('SyncExecutor onError Lifecycle', () => {
     const executor = new SyncExecutor();
     const plugin1: ExecutorPlugin = {
       pluginName: 'test',
-      onError: ({ error }) => new ExecutorError('Handled by plugin1', error)
+      onError: ({ error, hooksRuntimes }) => {
+        // break the chain
+        hooksRuntimes.returnBreakChain = true;
+
+        return new ExecutorError('Handled by plugin1', error);
+      }
     };
     const plugin2: ExecutorPlugin = {
       pluginName: 'test2',

--- a/packages/fe-utils/common/__tests__/request/plugins/FetchAbortPlugin.test.ts
+++ b/packages/fe-utils/common/__tests__/request/plugins/FetchAbortPlugin.test.ts
@@ -172,7 +172,10 @@ describe('FetchAbortPlugin with multiple plugins', () => {
     const abortPlugin = new FetchAbortPlugin();
     const TestErrorPlugin: ExecutorPlugin = {
       pluginName: 'TestErrorPlugin',
-      onError: vi.fn((): RequestError => {
+      onError: vi.fn(({ hooksRuntimes }): RequestError => {
+        // break the chain
+        hooksRuntimes.returnBreakChain = true;
+
         return new RequestError(
           RequestErrorID.ABORT_ERROR,
           'TestErrorPlugin abort'
@@ -285,6 +288,7 @@ describe('FetchAbortPlugin with multiple plugins', () => {
     }
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(TestErrorPlugin.onError).toHaveBeenCalledTimes(0);
+    // Executor v1.1.4 add firstErrorBreak
+    expect(TestErrorPlugin.onError).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/fe-utils/common/executor/impl/AsyncExecutor.ts
+++ b/packages/fe-utils/common/executor/impl/AsyncExecutor.ts
@@ -30,7 +30,7 @@ import {
  *
  * @category AsyncExecutor
  */
-export class AsyncExecutor extends Executor {
+export class AsyncExecutor<ExecutorConfig> extends Executor<ExecutorConfig> {
   /**
    * Execute plugin hook functions asynchronously
    *
@@ -300,9 +300,6 @@ export class AsyncExecutor extends Executor {
       return context.returnValue as Result;
     } catch (error) {
       context.error = error as Error;
-
-      // if onError hook return a Error, then break the chain
-      Object.assign(context.hooksRuntimes, { returnBreakChain: true });
 
       await this.runHooks(this.plugins, 'onError', context);
 

--- a/packages/fe-utils/common/executor/impl/SyncExecutor.ts
+++ b/packages/fe-utils/common/executor/impl/SyncExecutor.ts
@@ -322,9 +322,6 @@ export class SyncExecutor extends Executor {
     } catch (error) {
       context.error = error as Error;
 
-      // if onError hook return a Error, then break the chain
-      Object.assign(context.hooksRuntimes, { returnBreakChain: true });
-
       this.runHooks(this.plugins, 'onError', context);
 
       // if onError hook return a ExecutorError, then throw it

--- a/packages/fe-utils/docs/common/logger/Logger.md
+++ b/packages/fe-utils/docs/common/logger/Logger.md
@@ -181,7 +181,7 @@ this.print(LEVELS.INFO, 'Information message');
 #### Parameters
 | Name | Description | Type | Default | Since |
 |------|------|---------|-------|------------|
-|  level  | Log level for the message | `LogLevel` |  |  |
+|  _level  |  | `LogLevel` |  |  |
 |  args  | Arguments to log | `unknown[]` |  |  |
 
 

--- a/packages/fe-utils/docs/interface/executor/Executor.md
+++ b/packages/fe-utils/docs/interface/executor/Executor.md
@@ -52,7 +52,7 @@ const executor = new Executor({
 #### Parameters
 | Name | Description | Type | Default | Since |
 |------|------|---------|-------|------------|
-|  config  | Optional configuration object | `ExecutorConfig` | {} |  |
+|  config  | Optional configuration object | `ExecutorConfig` |  |  |
 
 
 ### exec
@@ -228,87 +228,4 @@ executor.use({
 | Name | Description | Type | Default | Since |
 |------|------|---------|-------|------------|
 |  plugin  | Plugin instance to add | `ExecutorPlugin<unknown>` |  |  |
-
-
-## Interface `ExecutorConfig`
-Configuration interface for executor
-
-- Purpose: Provides configuration options for the Executor class
-- Core Concept: Extensible configuration container
-- Main Features: Currently empty but designed for future extension
-- Primary Use: Allows customization of executor behavior
-
-@example 
-
-Successfully execute an asynchronous task
-
-
-```typescript
-const executor = new AsyncExecutor();
-const result = await executor.exec(async () => 'success');
-
-// => result is 'success'
-```
-
-@example 
-
-Execute multiple plugins in order
-
-
-```typescript
-const executor = new AsyncExecutor();
-const steps: number[] = [];
-
-const plugin1: ExecutorPlugin = {
-  pluginName: 'test1',
-  onSuccess: () => {
-    steps.push(1);
-  }
-};
-
- const plugin2: ExecutorPlugin = {
-   pluginName: 'test2',
-   onSuccess: () => {
-     steps.push(2);
-   }
- };
-
- executor.use(plugin1);
- executor.use(plugin2);
-
- await executor.exec(async () => 'test');
-
- // => steps is [1, 2]
-```
-
-@example 
-
-If a plugin returns undefined, the chain should continue
-
-
-```typescript
-const executor = new AsyncExecutor();
-let finalResult = '';
-
-const plugin1: ExecutorPlugin = {
-  pluginName: 'test1',
-  onSuccess: (): undefined => undefined
-};
-
-const plugin2: ExecutorPlugin = {
-  pluginName: 'test2',
-  onSuccess: ({ returnValue }) => {
-    finalResult = returnValue + ' modified';
-    return finalResult;
-  }
-};
-
-executor.use(plugin1);
-executor.use(plugin2);
-
-const result = await executor.exec(async () => 'test');
-
-// => result is 'test modified'
-```
-
 

--- a/packages/fe-utils/interface/executor/Executor.ts
+++ b/packages/fe-utils/interface/executor/Executor.ts
@@ -2,87 +2,6 @@ import { ExecutorError } from './ExecutorError';
 import { ExecutorPlugin, Task } from './ExecutorPlugin';
 
 /**
- * Configuration interface for executor
- *
- * - Purpose: Provides configuration options for the Executor class
- * - Core Concept: Extensible configuration container
- * - Main Features: Currently empty but designed for future extension
- * - Primary Use: Allows customization of executor behavior
- *
- * @category Executor
- * @example
- *
- * Successfully execute an asynchronous task
- *
- * ```typescript
- * const executor = new AsyncExecutor();
- * const result = await executor.exec(async () => 'success');
- *
- * // => result is 'success'
- * ```
- *
- * @example
- *
- * Execute multiple plugins in order
- *
- * ```typescript
- * const executor = new AsyncExecutor();
- * const steps: number[] = [];
- *
- * const plugin1: ExecutorPlugin = {
- *   pluginName: 'test1',
- *   onSuccess: () => {
- *     steps.push(1);
- *   }
- * };
- *
- *  const plugin2: ExecutorPlugin = {
- *    pluginName: 'test2',
- *    onSuccess: () => {
- *      steps.push(2);
- *    }
- *  };
- *
- *  executor.use(plugin1);
- *  executor.use(plugin2);
- *
- *  await executor.exec(async () => 'test');
- *
- *  // => steps is [1, 2]
- * ```
- *
- * @example
- *
- * If a plugin returns undefined, the chain should continue
- *
- * ```typescript
- * const executor = new AsyncExecutor();
- * let finalResult = '';
- *
- * const plugin1: ExecutorPlugin = {
- *   pluginName: 'test1',
- *   onSuccess: (): undefined => undefined
- * };
- *
- * const plugin2: ExecutorPlugin = {
- *   pluginName: 'test2',
- *   onSuccess: ({ returnValue }) => {
- *     finalResult = returnValue + ' modified';
- *     return finalResult;
- *   }
- * };
- *
- * executor.use(plugin1);
- * executor.use(plugin2);
- *
- * const result = await executor.exec(async () => 'test');
- *
- * // => result is 'test modified'
- * ```
- */
-export interface ExecutorConfig {}
-
-/**
  * Base executor class providing plugin management and execution pipeline
  *
  * The Executor pattern implements a pluggable execution pipeline that allows:
@@ -111,7 +30,7 @@ export interface ExecutorConfig {}
  * });
  * ```
  */
-export abstract class Executor {
+export abstract class Executor<ExecutorConfig = unknown> {
   /**
    * Array of active plugins
    *
@@ -149,7 +68,7 @@ export abstract class Executor {
    * });
    * ```
    */
-  constructor(protected config: ExecutorConfig = {}) {}
+  constructor(protected config?: ExecutorConfig) {}
 
   /**
    * Add a plugin to the executor


### PR DESCRIPTION
Remove default interruption of return type after `onError` lifecycle trigger in `AsyncExecutor` and `SyncExecutor`