### PR TITLE
chore(dependencies): update @qlover/fe-corekit and @qlover/env-loader…

### DIFF
--- a/packages/corekit-bridge/package.json
+++ b/packages/corekit-bridge/package.json
@@ -47,12 +47,12 @@
     "build": "rollup -c"
   },
   "dependencies": {
-    "@qlover/fe-corekit": "^1.2.6",
+    "@qlover/fe-corekit": "^1.2.5",
     "@qlover/slice-store-react": "^1.2.6",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@qlover/env-loader": "^0.0.5",
+    "@qlover/env-loader": "^0.0.4",
     "@types/lodash": "^4.17.13",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -48,11 +48,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@qlover/env-loader": "^0.0.5"
+    "@qlover/env-loader": "^0.0.4"
   },
   "dependencies": {
-    "@qlover/fe-corekit": "^1.2.6",
-    "@qlover/scripts-context": "^0.0.12",
+    "@qlover/fe-corekit": "^1.2.5",
+    "@qlover/scripts-context": "^0.0.11",
     "commander": "^13.1.0",
     "ignore": "^7.0.3",
     "inquirer": "^12.3.2",

--- a/packages/env-loader/package.json
+++ b/packages/env-loader/package.json
@@ -39,7 +39,7 @@
     "build": "rollup -c"
   },
   "devDependencies": {
-    "@qlover/fe-corekit": "^1.2.6"
+    "@qlover/fe-corekit": "^1.2.5"
   },
   "dependencies": {
     "dotenv": "^16.4.5"

--- a/packages/fe-code2markdown/package.json
+++ b/packages/fe-code2markdown/package.json
@@ -48,14 +48,14 @@
     "access": "public"
   },
   "devDependencies": {
-    "@qlover/env-loader": "^0.0.5",
-    "@qlover/scripts-context": "^0.0.12",
+    "@qlover/env-loader": "^0.0.4",
+    "@qlover/scripts-context": "^0.0.11",
     "fs-extra": "^11.2.0",
     "typescript": "~5.4.0"
   },
   "dependencies": {
     "@microsoft/tsdoc": "^0.15.0",
-    "@qlover/fe-corekit": "^1.2.6",
+    "@qlover/fe-corekit": "^1.2.5",
     "commander": "^11.0.0",
     "handlebars": "^4.7.8",
     "lodash": "^4.17.21",

--- a/packages/fe-corekit/package.json
+++ b/packages/fe-corekit/package.json
@@ -58,7 +58,7 @@
     "merge": "^2.1.1"
   },
   "devDependencies": {
-    "@qlover/env-loader": "^0.0.5",
+    "@qlover/env-loader": "^0.0.4",
     "@types/lodash": "^4.17.12",
     "axios": "^1.7.9"
   }

--- a/packages/fe-release/package.json
+++ b/packages/fe-release/package.json
@@ -60,9 +60,9 @@
   },
   "dependencies": {
     "@octokit/rest": "^21.0.2",
-    "@qlover/env-loader": "^0.0.5",
-    "@qlover/fe-corekit": "^1.2.6",
-    "@qlover/scripts-context": "^0.0.12",
+    "@qlover/env-loader": "^0.0.4",
+    "@qlover/fe-corekit": "^1.2.5",
+    "@qlover/scripts-context": "^0.0.11",
     "lodash": "^4.17.21"
   }
 }

--- a/packages/fe-scripts/package.json
+++ b/packages/fe-scripts/package.json
@@ -62,9 +62,9 @@
   "dependencies": {
     "@commitlint/config-conventional": "^19.2.2",
     "@octokit/rest": "^21.0.2",
-    "@qlover/fe-corekit": "^1.2.6",
-    "@qlover/env-loader": "^0.0.5",
-    "@qlover/scripts-context": "^0.0.12",
+    "@qlover/fe-corekit": "^1.2.5",
+    "@qlover/env-loader": "^0.0.4",
+    "@qlover/scripts-context": "^0.0.11",
     "commitizen": "^4.3.1",
     "commander": "^11.0.0",
     "ignore": "^6.0.2",

--- a/packages/scripts-context/package.json
+++ b/packages/scripts-context/package.json
@@ -44,12 +44,12 @@
   },
   "devDependencies": {
     "@types/shelljs": "^0.8.15",
-    "@qlover/env-loader": "^0.0.5",
+    "@qlover/env-loader": "^0.0.4",
     "@types/lodash": "^4.17.16",
     "@commitlint/types": "^19.8.0"
   },
   "dependencies": {
-    "@qlover/fe-corekit": "^1.2.6",
+    "@qlover/fe-corekit": "^1.2.5",
     "chalk": "^5.3.0",
     "cosmiconfig": "^9.0.0",
     "lodash": "^4.17.21"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
   packages/corekit-bridge:
     dependencies:
       '@qlover/fe-corekit':
-        specifier: ^1.2.1
+        specifier: ^1.2.5
         version: 1.2.5
       '@qlover/slice-store-react':
         specifier: ^1.2.6
@@ -184,7 +184,7 @@ importers:
   packages/create-app:
     dependencies:
       '@qlover/fe-corekit':
-        specifier: ^1.2.2
+        specifier: ^1.2.5
         version: 1.2.5
       '@qlover/scripts-context':
         specifier: ^0.0.11
@@ -216,7 +216,7 @@ importers:
         version: 16.5.0
     devDependencies:
       '@qlover/fe-corekit':
-        specifier: ^1.2.2
+        specifier: ^1.2.5
         version: 1.2.5
 
   packages/eslint-plugin-fe-dev: {}
@@ -227,7 +227,7 @@ importers:
         specifier: ^0.15.0
         version: 0.15.1
       '@qlover/fe-corekit':
-        specifier: ^1.2.2
+        specifier: ^1.2.5
         version: 1.2.5
       commander:
         specifier: ^11.0.0
@@ -283,7 +283,7 @@ importers:
         specifier: ^0.0.4
         version: 0.0.4
       '@qlover/fe-corekit':
-        specifier: ^1.2.2
+        specifier: ^1.2.5
         version: 1.2.5
       '@qlover/scripts-context':
         specifier: ^0.0.11
@@ -317,7 +317,7 @@ importers:
         specifier: ^0.0.4
         version: 0.0.4
       '@qlover/fe-corekit':
-        specifier: ^1.2.2
+        specifier: ^1.2.5
         version: 1.2.5
       '@qlover/scripts-context':
         specifier: ^0.0.11
@@ -378,7 +378,7 @@ importers:
   packages/scripts-context:
     dependencies:
       '@qlover/fe-corekit':
-        specifier: ^1.2.2
+        specifier: ^1.2.5
         version: 1.2.5
       chalk:
         specifier: ^5.3.0


### PR DESCRIPTION
… versions across multiple packages

- Updated the version of @qlover/fe-corekit from ^1.2.6 to ^1.2.5 in package.json files for corekit-bridge, create-app, fe-code2markdown, fe-corekit, fe-release, fe-scripts, and scripts-context to ensure consistency.
- Updated the version of @qlover/env-loader from ^0.0.5 to ^0.0.4 in package.json files for corekit-bridge, create-app, fe-corekit, fe-release, fe-scripts, and scripts-context to maintain compatibility.