### PR TITLE
refactor(env-loader): replace @qlover/fe-corekit with @qlover/logger

### DIFF
--- a/packages/env-loader/__tests__/Env.test.ts
+++ b/packages/env-loader/__tests__/Env.test.ts
@@ -1,5 +1,5 @@
 import { Env } from '../src/Env';
-import { Logger } from '@qlover/fe-corekit';
+import type { LoggerInterface } from '@qlover/logger';
 import { config } from 'dotenv';
 import { existsSync } from 'node:fs';
 import { resolve, normalize } from 'path';
@@ -12,7 +12,7 @@ function toLocalPath(pathstring: string): string {
 }
 
 describe('Env', () => {
-  let logger: Logger;
+  let logger: LoggerInterface;
 
   beforeEach(() => {
     logger = {

--- a/packages/env-loader/package.json
+++ b/packages/env-loader/package.json
@@ -39,7 +39,7 @@
     "build": "rollup -c"
   },
   "devDependencies": {
-    "@qlover/fe-corekit": "latest"
+    "@qlover/logger": "workspace:*"
   },
   "dependencies": {
     "dotenv": "^16.4.5"

--- a/packages/env-loader/src/Env.ts
+++ b/packages/env-loader/src/Env.ts
@@ -1,7 +1,7 @@
 import { config } from 'dotenv';
 import { existsSync } from 'node:fs';
 import { resolve, dirname } from 'path';
-import { Logger } from '@qlover/fe-corekit';
+import type { LoggerInterface } from '@qlover/logger';
 
 /**
  * Environment configuration options interface
@@ -23,7 +23,7 @@ interface EnvOptions {
   /** Root path for environment files */
   rootPath: string;
   /** Logger instance */
-  logger?: Logger | typeof console;
+  logger?: LoggerInterface | typeof console;
 }
 
 /**
@@ -89,7 +89,7 @@ export class Env {
     return this.options.rootPath;
   }
 
-  get logger(): Logger | typeof console | undefined {
+  get logger(): LoggerInterface | typeof console | undefined {
     return this.options.logger;
   }
 
@@ -98,7 +98,7 @@ export class Env {
    * @param {object} options
    * @param {string} [options.cwd] start search directory, default is process.cwd()
    * @param {string[]} [options.preloadList] search file name list, default is ['.env.local', '.env']
-   * @param {import('@qlover/fe-corekit').Logger} [options.logger] logger
+   * @param {Logger} [options.logger] logger
    * @param {number} [options.maxDepth=5] maximum search depth
    * @returns {Env} environment variable loader instance
    */
@@ -110,7 +110,7 @@ export class Env {
   }: {
     cwd?: string;
     preloadList?: string[];
-    logger?: Logger;
+    logger?: LoggerInterface;
     maxDepth?: number;
   } = {}): Env {
     // limit max search depth to 10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,9 @@ importers:
         specifier: ^16.4.5
         version: 16.5.0
     devDependencies:
-      '@qlover/fe-corekit':
-        specifier: latest
-        version: 1.3.0
+      '@qlover/logger':
+        specifier: workspace:*
+        version: link:../logger
 
   packages/eslint-plugin-fe-dev: {}
 
@@ -1773,9 +1773,6 @@ packages:
   '@pkgr/core@0.2.4':
     resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-
-  '@qlover/fe-corekit@1.3.0':
-    resolution: {integrity: sha512-SaAetUw7uktnF8cTYNb56krFeCQIFPL5yFDPCo5Qb+yZqxfl1gNi7EKnLPYuVZnSHea0CdQyg6wzmSALsAMXLA==}
 
   '@qlover/slice-store-react@1.2.6':
     resolution: {integrity: sha512-m0lUc8p4y7JiYAA5pxpGsuHeJnwW8Q7V1xH4KJb0qDd/STbHn1N/1eyGB4wRBxzv/8PYfJ125fYm06OU1OymWA==}
@@ -6802,11 +6799,6 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.4': {}
-
-  '@qlover/fe-corekit@1.3.0':
-    dependencies:
-      lodash: 4.17.21
-      merge: 2.1.1
 
   '@qlover/slice-store-react@1.2.6':
     dependencies:


### PR DESCRIPTION
- Updated dependencies in package.json and pnpm-lock.yaml to use @qlover/logger instead of @qlover/fe-corekit.
- Changed type references from Logger to LoggerInterface in Env.ts and Env.test.ts for improved type safety.
- Adjusted logger handling in the Env class to align with the new logger interface.