### PR TITLE
[release-@qlover/fe-release@2.1.5] Branch:master, Tag:@qloveer/fe-release@2.1.5, Env:production

### DIFF
--- a/packages/fe-corekit/CHANGELOG.md
+++ b/packages/fe-corekit/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @qlover/corekit-bridge
 
+## 1.3.3
+
+### Patch Changes
+
+#### ✨ Features
+
+- add option to ignore non-updated packages and enhance workspace handling (#385)
+
+  - Introduced `--changelog.ignore-non-updated-packages` CLI option to allow skipping non-updated packages in changelog generation.
+  - Updated `ChangelogProps` to include `ignoreNonUpdatedPackages` configuration.
+  - Enhanced `WorkspacesProps` to manage `changedPaths` and `packages` more effectively.
+  - Implemented `restoreIgnorePackages` method to restore non-changed packages during the changelog process.
+  - Adjusted package manager fallback from `npm` to `npx` for executing changeset commands.
+
+  ***
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/fe-corekit/CHANGELOG.md
+++ b/packages/fe-corekit/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @qlover/corekit-bridge
 
-## 1.3.3
-
-### Patch Changes
-
-#### ✨ Features
-
-- add option to ignore non-updated packages and enhance workspace handling (#385)
-
-  - Introduced `--changelog.ignore-non-updated-packages` CLI option to allow skipping non-updated packages in changelog generation.
-  - Updated `ChangelogProps` to include `ignoreNonUpdatedPackages` configuration.
-  - Enhanced `WorkspacesProps` to manage `changedPaths` and `packages` more effectively.
-  - Implemented `restoreIgnorePackages` method to restore non-changed packages during the changelog process.
-  - Adjusted package manager fallback from `npm` to `npx` for executing changeset commands.
-
-  ***
-
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/fe-corekit/package.json
+++ b/packages/fe-corekit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/fe-corekit",
   "description": "A corekit for frontwork",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": false,
   "type": "module",
   "files": [

--- a/packages/fe-corekit/package.json
+++ b/packages/fe-corekit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/fe-corekit",
   "description": "A corekit for frontwork",
-  "version": "1.3.3",
+  "version": "1.3.1",
   "private": false,
   "type": "module",
   "files": [

--- a/packages/fe-release/CHANGELOG.md
+++ b/packages/fe-release/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @qlover/fe-release
 
+## 2.1.5
+
+### Patch Changes
+
+#### ✨ Features
+
+- add option to ignore non-updated packages and enhance workspace handling (#385)
+
+  - Introduced `--changelog.ignore-non-updated-packages` CLI option to allow skipping non-updated packages in changelog generation.
+  - Updated `ChangelogProps` to include `ignoreNonUpdatedPackages` configuration.
+  - Enhanced `WorkspacesProps` to manage `changedPaths` and `packages` more effectively.
+  - Implemented `restoreIgnorePackages` method to restore non-changed packages during the changelog process.
+  - Adjusted package manager fallback from `npm` to `npx` for executing changeset commands.
+
+  ***
+
 ## 2.1.4
 
 ## 2.1.3

--- a/packages/fe-release/package.json
+++ b/packages/fe-release/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/fe-release",
   "description": "A tool for releasing front-end projects, supporting multiple release modes and configurations, simplifying the release process and improving efficiency.",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/fe-release",


### PR DESCRIPTION
## Publish Details

- 🏷️ Version: @qlover/fe-release@2.1.5
- 🌲 Branch: master
- 🔧 Environment: production

## Changelog

## @qlover/fe-release 2.1.5
#### ✨ Features
- add option to ignore non-updated packages and enhance workspace handling (#385)

  - Introduced `--changelog.ignore-non-updated-packages` CLI option to allow skipping non-updated packages in changelog generation.
  - Updated `ChangelogProps` to include `ignoreNonUpdatedPackages` configuration.
  - Enhanced `WorkspacesProps` to manage `changedPaths` and `packages` more effectively.
  - Implemented `restoreIgnorePackages` method to restore non-changed packages during the changelog process.
  - Adjusted package manager fallback from `npm` to `npx` for executing changeset commands.
  ----------------------


## Notes

- [ ] Please check if the version number is correct
- [ ] Please confirm all tests have passed
- [ ] Please confirm the documentation has been updated

> This PR is auto created by release process, please contact the frontend team if there are any questions.