### PR TITLE
refactor(githubPR): enhance PR handling logic and introduce publishPR…

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:fe-release": "pnpm --filter @qlover/fe-release build",
     "build:logger": "pnpm --filter @qlover/logger build",
     "dryrun:releasePR": "node ./packages/fe-release/dist/cli.js -V -P --githubPR.dry-run-create-PR",
-    "dryrun:release": "node ./packages/fe-release/dist/cli.js -V --githubPR.dry-run-create-PR",
+    "dryrun:release": "node ./packages/fe-release/dist/cli.js -V --changelog.skip-changeset --githubPR.dry-run-create-PR",
     "release": "pnpm --filter @qlover/fe-release release",
     "nx:build": "nx affected:build",
     "prettier": "prettier --ignore-path .prettierignore **/*.{js,ts,json,cjs,mjs} --write",


### PR DESCRIPTION
… method

- Updated the onSuccess method to conditionally call publishPR or releasePR based on the isPublish flag.
- Removed redundant checks for onExec and onSuccess methods.
- Added a new publishPR method to handle publishing logic separately, improving code clarity and maintainability.
- Modified the dryrun:release script in package.json to include changelog skipping option.