### PR TITLE
feat(changelog): add support for commit body in changelog generation

### DIFF
--- a/fe-config.json
+++ b/fe-config.json
@@ -7,6 +7,7 @@
     },
     "changelog": {
       "formatTemplate": "\n- ${scopeHeader} ${commitlint.message} ${commitLink} ${prLink}",
+      "commitBody": true,
       "types": [
         { "type": "feat", "section": "#### ✨ Features", "hidden": false },
         { "type": "fix", "section": "#### 🐞 Bug Fixes", "hidden": false },

--- a/packages/fe-release/__tests__/implements/changelog/GitChangelog.test.ts
+++ b/packages/fe-release/__tests__/implements/changelog/GitChangelog.test.ts
@@ -55,6 +55,19 @@ describe('GitChangelog', () => {
         message: 'improve button design'
       });
     });
+
+    it('should handle PR references in commit messages with body', () => {
+      const messageBody = '\n\nThis is a detailed description of the feature.';
+      const message = 'feat(ui): improve button design (#123)' + messageBody;
+      const result = gitChangelog.parseCommitlint(message, message);
+
+      expect(result).toEqual({
+        type: 'feat',
+        scope: 'ui',
+        message: 'improve button design',
+        body: messageBody
+      });
+    });
   });
 
   describe('toCommitValue', () => {

--- a/packages/fe-release/__tests__/implements/changelog/GitChangelogFormatter.test.ts
+++ b/packages/fe-release/__tests__/implements/changelog/GitChangelogFormatter.test.ts
@@ -203,7 +203,8 @@ describe('GitChangelogFormatter', () => {
           commitlint: {
             type: 'feat',
             scope: 'ui',
-            message: 'add new feature'
+            message: 'add new feature',
+            body: 'Detailed description\nMultiple lines'
           },
           commits: []
         }
@@ -211,7 +212,10 @@ describe('GitChangelogFormatter', () => {
 
       const typeConfig = [{ type: 'feat', section: '### Features' }];
 
-      const result = formatter.format(commits, { types: typeConfig });
+      const result = formatter.format(commits, {
+        types: typeConfig,
+        commitBody: true
+      });
 
       expect(result).toEqual([
         '### Features',

--- a/packages/fe-release/src/implments/changelog/GitChangeLog.ts
+++ b/packages/fe-release/src/implments/changelog/GitChangeLog.ts
@@ -104,14 +104,14 @@ export class GitChangelog implements ChangeLogInterface {
         type: titleMatch[1]?.toLowerCase(),
         scope: titleMatch[2]?.trim(),
         message: titleMatch[3].trim(),
-        body: bodyLines
+        body: bodyLines || undefined
       };
     }
 
     return {
       // message: title.replace(/\s*\(#\d+\)\s*$/, '').trim()
       message: title,
-      body: bodyLines
+      body: bodyLines || undefined
     };
   }
 

--- a/packages/fe-release/src/implments/changelog/GitChangelogFormatter.ts
+++ b/packages/fe-release/src/implments/changelog/GitChangelogFormatter.ts
@@ -21,7 +21,7 @@ export class GitChangelogFormatter implements ChangelogFormatter {
   ) {}
 
   format(commits: CommitValue[], options?: Options): string[] {
-    const { types = [] } = { ...this.options, ...options };
+    const { types = [], commitBody = false } = { ...this.options, ...options };
     const changelog: string[] = [];
 
     const groupedCommits = groupBy(commits, (commit) => {
@@ -44,8 +44,8 @@ export class GitChangelogFormatter implements ChangelogFormatter {
         typeCommits.forEach((commit) => {
           changelog.push(this.formatCommit(commit, options));
 
-          if (commit.base.body) {
-            const bodyLines = commit.base.body
+          if (commitBody && commit.commitlint.body) {
+            const bodyLines = commit.commitlint.body
               .split('\n')
               .map((line) => `  ${line}`);
             changelog.push(...bodyLines);

--- a/packages/fe-release/src/interface/ChangeLog.ts
+++ b/packages/fe-release/src/interface/ChangeLog.ts
@@ -44,6 +44,13 @@ export interface GitChangelogOptions {
    * @default '\n- ${scopeHeader} ${commitlint.message} ${commitLink} ${prLink}'
    */
   formatTemplate?: string;
+
+  /**
+   * whether to include commit body
+   * @since 2.3.0
+   * @default false
+   */
+  commitBody?: boolean;
 }
 
 export interface CommitTuple {
@@ -58,6 +65,11 @@ export interface Commitlint {
   type?: string;
   scope?: string;
   message: string;
+  /**
+   * commit body, remove repeat title
+   * @since 2.3.0
+   */
+  body?: string;
 }
 
 export interface CommitValue {


### PR DESCRIPTION
- Updated GitChangelog to parse and include commit body along with the title.
- Enhanced GitChangelogFormatter to conditionally format and display commit body in the changelog.
- Introduced commitBody option in GitChangelogOptions to control the inclusion of commit body in the output.
- Updated related interfaces to accommodate the new body field in commitlint.