### PR TITLE
[release-@qlover/fe-release-2.3.0 Release] Branch:master, Tag:2.3.0, Env:production

### DIFF
--- a/packages/fe-release/CHANGELOG.md
+++ b/packages/fe-release/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @qlover/fe-release
 
+## 2.3.0
+
+### Minor Changes
+
+#### ✨ Features
+
+- **changelog:** add support for commit body in changelog generation ([5383055](https://github.com/qlover/fe-base/commit/5383055d2abb095df40575ce2d40e4c40827e422)) ([#398](https://github.com/qlover/fe-base/pull/398))
+
+  - Updated GitChangelog to parse and include commit body along with the title.
+  - Enhanced GitChangelogFormatter to conditionally format and display commit body in the changelog.
+  - Introduced commitBody option in GitChangelogOptions to control the inclusion of commit body in the output.
+  - Updated related interfaces to accommodate the new body field in commitlint.
+
+  Co-authored-by: QRJ <renjie.qin@brain.im>
+
 ## 2.2.0
 
 ### Minor Changes

--- a/packages/fe-release/package.json
+++ b/packages/fe-release/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/fe-release",
   "description": "A tool for releasing front-end projects, supporting multiple release modes and configurations, simplifying the release process and improving efficiency.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/fe-release",


### PR DESCRIPTION
## Publish Details

- 🏷️ Version: 2.3.0
- 🌲 Branch: master
- 🔧 Environment: production

## Changelog

#### ✨ Features

- **changelog:** add support for commit body in changelog generation ([5383055](https://github.com/qlover/fe-base/commit/5383055d2abb095df40575ce2d40e4c40827e422)) ([#398](https://github.com/qlover/fe-base/pull/398))
  
  
  - Updated GitChangelog to parse and include commit body along with the title.
  - Enhanced GitChangelogFormatter to conditionally format and display commit body in the changelog.
  - Introduced commitBody option in GitChangelogOptions to control the inclusion of commit body in the output.
  - Updated related interfaces to accommodate the new body field in commitlint.
  
  Co-authored-by: QRJ <renjie.qin@brain.im>

## Notes

- [ ] Please check if the version number is correct
- [ ] Please confirm all tests have passed
- [ ] Please confirm the documentation has been updated

> This PR is auto created by release process, please contact the frontend team if there are any questions.