### PR TITLE
fix(changelog): conditionally execute git restore for unchanged packages

### DIFF
--- a/packages/fe-release/src/plugins/Changelog.ts
+++ b/packages/fe-release/src/plugins/Changelog.ts
@@ -192,7 +192,9 @@ export default class Changelog extends Plugin<ChangelogProps> {
 
     this.logger.debug('noChangedPackages', noChangedPackages);
 
-    await this.shell.exec(['git', 'restore', ...noChangedPackages]);
+    if (noChangedPackages.length > 0) {
+      await this.shell.exec(['git', 'restore', ...noChangedPackages]);
+    }
   }
 
   getTagPrefix(workspace: WorkspaceValue): string {


### PR DESCRIPTION
- Added a check to ensure that the git restore command is only executed if there are packages that have not changed, improving the efficiency of the Changelog plugin.