### PR TITLE
test: add github cicd test git log commit

### DIFF
--- a/.github/workflows/general-check.yml
+++ b/.github/workflows/general-check.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          # ref: ${{ github.head_ref || github.ref_name }}
+          fetch-tags: true
 
       - name: Config Git
         run: |
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          # ref: ${{ github.head_ref || github.ref_name }}
+          fetch-tags: true
 
       - name: Config Git
         run: |

--- a/packages/fe-release/src/implments/changelog/GitChangeLog.ts
+++ b/packages/fe-release/src/implments/changelog/GitChangeLog.ts
@@ -6,7 +6,8 @@ import type {
   CommitValue,
   GitChangelogOptions
 } from '../../interface/ChangeLog';
-import gitlog, { CommitField } from 'gitlog';
+import gitlog, { CommitField, GitlogOptions } from 'gitlog';
+import type { LoggerInterface } from '@qlover/logger';
 
 export const CHANGELOG_ALL_FIELDS: CommitField[] = [
   'hash',
@@ -31,6 +32,7 @@ export const CHANGELOG_ALL_FIELDS: CommitField[] = [
 
 export interface GitChangelogProps extends GitChangelogOptions {
   shell: Shell;
+  logger: LoggerInterface;
 }
 
 export class GitChangelog implements ChangeLogInterface {
@@ -50,7 +52,7 @@ export class GitChangelog implements ChangeLogInterface {
 
     const range = from === to ? to : `${from}..${to}`;
 
-    const commits = await gitlog({
+    const gitLogOptions: GitlogOptions<CommitField> = {
       repo: '.',
       number: 1000,
       fields: fileds,
@@ -58,7 +60,12 @@ export class GitChangelog implements ChangeLogInterface {
       file: directory,
       nameStatus: false,
       includeMergeCommitFiles: !noMerges
-    });
+    };
+
+    const commits = await gitlog(gitLogOptions);
+
+    this.options.logger?.debug('GitChangelog', gitLogOptions);
+    this.options.logger?.debug('GitChangelog commits', commits);
 
     return commits;
   }

--- a/packages/fe-release/src/plugins/Changelog.ts
+++ b/packages/fe-release/src/plugins/Changelog.ts
@@ -216,7 +216,8 @@ export default class Changelog extends Plugin<ChangelogProps> {
       from: tagName,
       directory: workspace.path,
       shell: this.shell,
-      fileds: CHANGELOG_ALL_FIELDS
+      fileds: CHANGELOG_ALL_FIELDS,
+      logger: this.logger
     };
 
     const gitChangelog = new GitChangelog(props);

--- a/packages/fe-release/src/plugins/githubPR/GithubChangelog.ts
+++ b/packages/fe-release/src/plugins/githubPR/GithubChangelog.ts
@@ -73,7 +73,8 @@ export default class GithubChangelog extends GitChangelog {
       ...(context.getConfig('changelog') as GitChangelogOptions),
       githubRootPath,
       mergePRcommit: true,
-      shell: context.shell
+      shell: context.shell,
+      logger: context.logger
     };
     const githubChangelog = new GithubChangelog(
       changelogProps,

--- a/packages/fe-release/src/plugins/githubPR/GithubPR.ts
+++ b/packages/fe-release/src/plugins/githubPR/GithubPR.ts
@@ -190,7 +190,6 @@ export default class GithubPR extends GitBase<GithubPRProps> {
     });
 
     this.context.setWorkspaces(newWorkspaces);
-    this.logger.debug('github changelog', this.context.workspaces);
   }
 
   override async onSuccess(): Promise<void> {


### PR DESCRIPTION
- Update GitHub workflows and enhance changelog functionality
- Added `fetch-tags: true` to the checkout step in both `general-check.yml` and `release.yml` workflows to ensure all tags are fetched during CI runs.
- Enhanced `GitChangeLog` implementation by introducing a `logger` property for better debugging and logging capabilities.
- Updated `Changelog` and `GithubChangelog` plugins to utilize the new `logger` property, improving traceability of changelog generation processes.

These changes improve the CI workflows and provide better insights during changelog generation.