### PR TITLE
[release-@qlover/corekit-bridge-1.1.1 Release] Branch:master, Tag:1.1.1, Env:production

### DIFF
--- a/packages/corekit-bridge/CHANGELOG.md
+++ b/packages/corekit-bridge/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @qlover/corekit-bridge
 
+## 1.1.1
+
+### Patch Changes
+
+#### ✨ Features
+
+- **corekit-bridge:** add unit tests for RequestCommonPlugin ([7703647](https://github.com/qlover/fe-base/commit/7703647730153726bbc190132dc2fb4167a46fea)) ([#447](https://github.com/qlover/fe-base/pull/447))
+
+  - Introduced comprehensive unit tests for the RequestCommonPlugin, covering initialization, token handling, header management, request data merging, and response processing.
+  - Enhanced test coverage for various scenarios, including edge cases and integration flows, ensuring robust functionality and reliability of the plugin.
+
+  These additions improve the overall test suite for the corekit-bridge, facilitating better maintenance and confidence in the plugin's behavior.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/corekit-bridge/package.json
+++ b/packages/corekit-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/corekit-bridge",
   "description": "fe-corekit Abstraction tool bridge for real development environments",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "type": "module",
   "files": [


### PR DESCRIPTION
## Publish Details

- 🏷️ Version: 1.1.1
- 🌲 Branch: master
- 🔧 Environment: production

## Changelog

#### ✨ Features

- **corekit-bridge:** add unit tests for RequestCommonPlugin ([7703647](https://github.com/qlover/fe-base/commit/7703647730153726bbc190132dc2fb4167a46fea)) ([#447](https://github.com/qlover/fe-base/pull/447))
    
    
    - Introduced comprehensive unit tests for the RequestCommonPlugin, covering initialization, token handling, header management, request data merging, and response processing.
    - Enhanced test coverage for various scenarios, including edge cases and integration flows, ensuring robust functionality and reliability of the plugin.
    
    These additions improve the overall test suite for the corekit-bridge, facilitating better maintenance and confidence in the plugin's behavior.

## Notes

- [ ] Please check if the version number is correct
- [ ] Please confirm all tests have passed
- [ ] Please confirm the documentation has been updated

> This PR is auto created by release process, please contact the frontend team if there are any questions.