### PR TITLE
[release-@qlover/corekit-bridge-1.1.2 Release] Branch:master, Tag:1.1.2, Env:production

### DIFF
--- a/packages/corekit-bridge/CHANGELOG.md
+++ b/packages/corekit-bridge/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @qlover/corekit-bridge
 
+## 1.1.2
+
+### Patch Changes
+
+#### ✨ Features
+
+- **corekit-bridge:** refactor user authentication interfaces and enhance token management ([12770ce](https://github.com/qlover/fe-base/commit/12770cec8eee16740823dee0deead528aea1ec3a)) ([#449](https://github.com/qlover/fe-base/pull/449))
+
+  - Updated UserAuthService to use `api` instead of `service` for improved clarity in the authentication flow.
+  - Introduced `setUserAuthStore` method in UserAuthApiInterface to manage user authentication storage.
+  - Enhanced UserAuthStore with methods to set and get user tokens, improving token management capabilities.
+  - Made storage options in UserToken interface optional, allowing for more flexible configurations.
+  - Added comprehensive unit tests to validate the new implementations and ensure robust functionality.
+
+  These changes improve the overall structure and maintainability of the user authentication system within the corekit-bridge.
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/corekit-bridge/package.json
+++ b/packages/corekit-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/corekit-bridge",
   "description": "fe-corekit Abstraction tool bridge for real development environments",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": false,
   "type": "module",
   "files": [


### PR DESCRIPTION
## Publish Details

- 🏷️ Version: 1.1.2
- 🌲 Branch: master
- 🔧 Environment: production

## Changelog

#### ✨ Features

- **corekit-bridge:** refactor user authentication interfaces and enhance token management ([12770ce](https://github.com/qlover/fe-base/commit/12770cec8eee16740823dee0deead528aea1ec3a)) ([#449](https://github.com/qlover/fe-base/pull/449))
    
    
    - Updated UserAuthService to use `api` instead of `service` for improved clarity in the authentication flow.
    - Introduced `setUserAuthStore` method in UserAuthApiInterface to manage user authentication storage.
    - Enhanced UserAuthStore with methods to set and get user tokens, improving token management capabilities.
    - Made storage options in UserToken interface optional, allowing for more flexible configurations.
    - Added comprehensive unit tests to validate the new implementations and ensure robust functionality.
    
    These changes improve the overall structure and maintainability of the user authentication system within the corekit-bridge.

## Notes

- [ ] Please check if the version number is correct
- [ ] Please confirm all tests have passed
- [ ] Please confirm the documentation has been updated

> This PR is auto created by release process, please contact the frontend team if there are any questions.