### PR TITLE
refactor(workflow): update build command in release.yml to use HEAD~1…

### DIFF
--- a/.github/workflows/general-check.yml
+++ b/.github/workflows/general-check.yml
@@ -31,7 +31,12 @@ jobs:
       - run: pnpm lint
       - run: pnpm test
       
-      - run: pnpm nx:build --base=origin/${{ github.base_ref }} --head=HEAD
+      # CI environment does not have .nx/cache cache, and each new build cannot read the cache, 
+      # if there is no cache from the last time, then other packages will not produce dist, but the local will read it directly from .nx/cache
+      # TODO: solve nx cache, use incremental build
+      # - run: pnpm nx:build --base=origin/${{ github.base_ref }} --head=HEAD --skip-nx-cache
+      - run: pnpm nx:build:force
+
       - run: pnpm rebuild
 
       - name: Check packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,13 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
-      - run: pnpm nx:build --base=HEAD~1 --head=HEAD
+
+      # CI environment does not have .nx/cache cache, and each new build cannot read the cache, 
+      # if there is no cache from the last time, then other packages will not produce dist, but the local will read it directly from .nx/cache
+      # TODO: solve nx cache, use incremental build
+      # - run: pnpm nx:build --base=HEAD~1 --head=HEAD
+      - run: pnpm nx:build:force
+
       - run: pnpm rebuild
 
       - name: Release Pull Request
@@ -73,7 +79,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
-      - run: pnpm nx:build --base=HEAD~1 --head=HEAD
+
+      # CI environment does not have .nx/cache cache, and each new build cannot read the cache, 
+      # if there is no cache from the last time, then other packages will not produce dist, but the local will read it directly from .nx/cache
+      # TODO: solve nx cache, use incremental build
+      # - run: pnpm nx:build --base=HEAD~1 --head=HEAD
+
+      - run: pnpm nx:build:force
+
       - run: pnpm rebuild
 
       - name: Create tag and publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
-      - run: pnpm nx:build --base=origin/${{ github.base_ref }} --head=HEAD
+      - run: pnpm nx:build --base=HEAD~1 --head=HEAD
       - run: pnpm rebuild
 
       - name: Release Pull Request
@@ -73,7 +73,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
-      - run: pnpm nx:build --base=origin/${{ github.base_ref }} --head=HEAD
+      - run: pnpm nx:build --base=HEAD~1 --head=HEAD
       - run: pnpm rebuild
 
       - name: Create tag and publish

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dryrun:release": "node ./packages/fe-release/dist/cli.js -V --changelog.skip-changeset --githubPR.dry-run-create-PR",
     "release": "pnpm --filter @qlover/fe-release release",
     "nx:build": "nx affected:build",
+    "nx:build:force": "pnpm nx run-many --target=build --all --skip-nx-cache --parallel --maxParallel=4",
     "prettier": "prettier --ignore-path .prettierignore **/*.{js,ts,json,cjs,mjs} --write",
     "lint": "eslint . --fix",
     "test": "vitest run",


### PR DESCRIPTION
… reference

- Modified the build command in the GitHub Actions workflow to use `HEAD~1` instead of `origin/${{ github.base_ref }}` for improved accuracy in build context.
- This change enhances the reliability of the build process during releases by ensuring the correct base reference is used.