### PR TITLE
feat(router): implement locale routing and enhance route configuration

### DIFF
--- a/packages/create-app/templates/react-app/config/app.router.ts
+++ b/packages/create-app/templates/react-app/config/app.router.ts
@@ -161,3 +161,158 @@ export const baseRoutes: RouteConfigValue[] = [
     }
   }
 ];
+
+export const baseNoLocaleRoutes: RouteConfigValue[] = [
+  {
+    path: '/',
+    element: 'base/Layout',
+    meta: {
+      category: 'main'
+    },
+    children: [
+      {
+        index: true,
+        element: 'base/HomePage',
+        meta: {
+          title: identifier.PAGE_HOME_TITLE,
+          description: identifier.PAGE_HOME_DESCRIPTION,
+          icon: 'home',
+          localNamespace: 'common'
+        }
+      },
+      {
+        path: 'about',
+        element: 'base/AboutPage',
+        meta: {
+          title: identifier.PAGE_ABOUT_TITLE,
+          description: identifier.PAGE_ABOUT_DESCRIPTION,
+          icon: 'info',
+          localNamespace: 'common'
+        }
+      },
+      {
+        path: 'jsonStorage',
+        element: 'base/JSONStoragePage',
+        meta: {
+          title: identifier.PAGE_JSONSTORAGE_TITLE,
+          description: identifier.PAGE_JSONSTORAGE_DESCRIPTION,
+          icon: 'info',
+          localNamespace: 'common'
+        }
+      },
+      {
+        path: 'request',
+        element: 'base/RequestPage',
+        meta: {
+          title: identifier.PAGE_REQUEST_TITLE,
+          description: identifier.PAGE_REQUEST_DESCRIPTION,
+          icon: 'info',
+          localNamespace: 'common'
+        }
+      },
+      {
+        path: 'executor',
+        element: 'base/ExecutorPage',
+        meta: {
+          title: identifier.PAGE_EXECUTOR_TITLE,
+          description: identifier.PAGE_EXECUTOR_DESCRIPTION,
+          icon: 'info',
+          localNamespace: 'common'
+        }
+      },
+      {
+        path: 'errorIdentifier',
+        element: 'base/ErrorIdentifierPage',
+        meta: {
+          title: identifier.PAGE_ERROR_IDENTIFIER_TITLE,
+          description: identifier.PAGE_ERROR_IDENTIFIER_DESCRIPTION,
+          icon: 'info',
+          localNamespace: 'common'
+        }
+      },
+      {
+        path: '404',
+        element: '404',
+        meta: {
+          category: 'common',
+          title: identifier.PAGE_404_TITLE,
+          description: identifier.PAGE_404_DESCRIPTION,
+          localNamespace: 'common'
+        }
+      },
+      {
+        path: '500',
+        element: '500',
+        meta: {
+          category: 'common',
+          title: identifier.PAGE_500_TITLE,
+          description: identifier.PAGE_500_DESCRIPTION,
+          localNamespace: 'common'
+        }
+      }
+    ]
+  },
+  {
+    path: '/',
+    element: 'auth/Layout',
+    meta: {
+      category: 'auth'
+    },
+    children: [
+      {
+        index: true,
+        element: 'auth/LoginPage'
+      },
+      {
+        path: 'login',
+        element: 'auth/LoginPage',
+        meta: {
+          title: identifier.PAGE_LOGIN_TITLE,
+          description: identifier.PAGE_LOGIN_DESCRIPTION,
+          icon: 'info',
+          localNamespace: 'common'
+        }
+      },
+      {
+        path: 'register',
+        element: 'auth/RegisterPage',
+        meta: {
+          title: identifier.PAGE_REGISTER_TITLE,
+          description: identifier.PAGE_REGISTER_DESCRIPTION,
+          icon: 'info',
+          localNamespace: 'common'
+        }
+      }
+    ]
+  },
+  {
+    path: '404',
+    element: '404',
+    meta: {
+      category: 'common',
+      title: identifier.PAGE_404_TITLE,
+      description: identifier.PAGE_404_DESCRIPTION,
+      localNamespace: 'common'
+    }
+  },
+  {
+    path: '500',
+    element: '500',
+    meta: {
+      category: 'common',
+      title: identifier.PAGE_500_TITLE,
+      description: identifier.PAGE_500_DESCRIPTION,
+      localNamespace: 'common'
+    }
+  },
+  {
+    path: '*',
+    element: '404',
+    meta: {
+      category: 'common',
+      title: identifier.PAGE_404_TITLE,
+      description: identifier.PAGE_404_DESCRIPTION,
+      localNamespace: 'common'
+    }
+  }
+];

--- a/packages/create-app/templates/react-app/config/common.ts
+++ b/packages/create-app/templates/react-app/config/common.ts
@@ -16,7 +16,7 @@ export const overrideAntdThemeMode: ViteDeprecatedAntdOptions['mode'] =
   'noGlobals';
 
 /**
- * bootstrap ,not inject env
+ * 启动器环境变量注入黑名单
  */
 export const envBlackList = ['env', 'userNodeEnv'];
 
@@ -37,3 +37,11 @@ export const loggerStyles = {
  * - 但是不能只有 /
  */
 export const routerPrefix = '/router-root';
+
+/**
+ * 是否使用本地化路由
+ *
+ * - true: 使用本地化路由，路由会带有语言前缀 (例如: /en/home)
+ * - false: 不使用本地化路由，直接使用路径 (例如: /home)
+ */
+export const useLocaleRoutes = true;

--- a/packages/create-app/templates/react-app/src/core/registers/RegisterCommon.ts
+++ b/packages/create-app/templates/react-app/src/core/registers/RegisterCommon.ts
@@ -16,7 +16,8 @@ import { themeConfig } from '@config/theme';
 import { localStorage, logger } from '../globals';
 import { I18nService } from '@/base/services/I18nService';
 import { RouteService } from '@/base/services/RouteService';
-import { baseRoutes } from '@config/app.router';
+import { baseRoutes, baseNoLocaleRoutes } from '@config/app.router';
+import { useLocaleRoutes } from '@config/common';
 import { UserService } from '@/base/services/UserService';
 import { IOCRegister } from '../IOC';
 import { IOCIdentifier } from '@config/IOCIdentifier';
@@ -62,8 +63,9 @@ export const RegisterCommon: IOCRegister = {
     container.bind(
       RouteService,
       new RouteService({
-        routes: baseRoutes,
-        logger
+        routes: useLocaleRoutes ? baseRoutes : baseNoLocaleRoutes,
+        logger,
+        hasLocalRoutes: useLocaleRoutes
       })
     );
 

--- a/packages/create-app/templates/react-app/src/pages/404.tsx
+++ b/packages/create-app/templates/react-app/src/pages/404.tsx
@@ -8,7 +8,6 @@ export default function NotFound({ route }: { route?: string }) {
     <div className="flex flex-col justify-center min-h-screen py-6 bg-background sm:py-12">
       <div className="relative py-3 mx-auto sm:max-w-xl">
         <h1 className="text-text text-2xl font-bold text-center">
-          404 -
           {route ? `${t(NOT_FOUND_COMPONENT)}: ${route}` : t(PAGE_404_TITLE)}
         </h1>
       </div>

--- a/packages/create-app/templates/react-app/src/pages/500.tsx
+++ b/packages/create-app/templates/react-app/src/pages/500.tsx
@@ -7,7 +7,7 @@ export default function NotFound500() {
     <div className="flex flex-col justify-center min-h-screen py-6 bg-background sm:py-12">
       <div className="relative py-3 mx-auto sm:max-w-xl">
         <h1 className="text-text text-2xl font-bold text-center">
-          500 - {t(PAGE_500_TITLE)}
+          {t(PAGE_500_TITLE)}
         </h1>
       </div>
     </div>

--- a/packages/create-app/templates/react-app/src/pages/base/RedirectPathname.tsx
+++ b/packages/create-app/templates/react-app/src/pages/base/RedirectPathname.tsx
@@ -1,3 +1,5 @@
+import { RouteService } from '@/base/services/RouteService';
+import { IOC } from '@/core/IOC';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -6,7 +8,7 @@ const RedirectToDefault = () => {
 
   useEffect(() => {
     // Redirect to the default language path
-    navigate('/en', { replace: true });
+    IOC(RouteService).redirectToDefault(navigate);
   }, [navigate]);
 
   return null;

--- a/packages/create-app/templates/react-app/src/uikit/components/LocaleLink.tsx
+++ b/packages/create-app/templates/react-app/src/uikit/components/LocaleLink.tsx
@@ -1,5 +1,6 @@
 import { LinkProps, Link as RouterLink, To, useParams } from 'react-router-dom';
 import { ReactNode } from 'react';
+import { useLocaleRoutes } from '@config/common';
 
 interface LocaleLinkProps extends Omit<LinkProps, 'href' | 'to'> {
   href: string | To;
@@ -21,14 +22,15 @@ const LocaleLink: React.FC<LocaleLinkProps> = ({
   locale = locale || lng;
 
   const isDefaultLocale = locale === defaultLocale;
+  const shouldAddLocale = useLocaleRoutes && !isDefaultLocale;
 
   let localizedHref: string | To;
   if (typeof href === 'string') {
-    localizedHref = isDefaultLocale ? href : `/${locale}${href}`;
+    localizedHref = shouldAddLocale ? `/${locale}${href}` : href;
   } else {
     localizedHref = {
       ...href,
-      pathname: isDefaultLocale ? href.pathname : `/${locale}${href.pathname}`
+      pathname: shouldAddLocale ? `/${locale}${href.pathname}` : href.pathname
     };
   }
 

--- a/packages/create-app/templates/react-app/src/uikit/hooks/useI18nGuard.ts
+++ b/packages/create-app/templates/react-app/src/uikit/hooks/useI18nGuard.ts
@@ -1,4 +1,6 @@
-import { I18nService, I18nServiceLocale } from '@/base/services/I18nService';
+import { I18nServiceLocale } from '@/base/services/I18nService';
+import { RouteService } from '@/base/services/RouteService';
+import { IOC } from '@/core/IOC';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
@@ -15,10 +17,6 @@ export function useI18nGuard() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!lng) {
-      navigate('/404', { replace: true });
-    } else if (!I18nService.isValidLanguage(lng)) {
-      navigate('/404', { replace: true });
-    }
+    IOC(RouteService).i18nGuard(lng as I18nServiceLocale, navigate);
   }, [lng, navigate]);
 }


### PR DESCRIPTION
- Added support for locale-based routing in the application, allowing routes to include language prefixes.
- Introduced `baseNoLocaleRoutes` to manage routes without localization, improving flexibility in route handling.
- Updated `I18nService` to conditionally cache user language based on locale routing settings.
- Enhanced `RouteService` to handle locale routes and added methods for redirection and language validation.
- Modified `RegisterCommon` to utilize the appropriate route configuration based on locale settings.
- Updated various components and hooks to integrate with the new routing logic, ensuring seamless navigation and language handling.

These changes aim to improve the user experience by providing localized routes and better language management.