### PR TITLE
chore(tag): @qlover/corekit-bridge v1.6.2, @qlover/create-app v0.7.2,…

### DIFF
--- a/packages/corekit-bridge/package.json
+++ b/packages/corekit-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/corekit-bridge",
   "description": "fe-corekit Abstraction tool bridge for real development environments",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": false,
   "type": "module",
   "files": [

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlover/create-app",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Create a new app with a single command",
   "private": false,
   "type": "module",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "ESLint plugin for qlover's TypeScript projects",
   "type": "module",
+  "private": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
… @qlover/eslint-plugin v1.0.1 (#490)

- Updated version numbers for @qlover/corekit-bridge and @qlover/create-app to v1.6.2 and v0.7.2 respectively.
- Added "private": false to @qlover/eslint-plugin package.json to clarify its visibility.

These changes ensure that the packages are up-to-date and properly configured for usage.