### PR TITLE
[release-@qlover/scripts-context-1.1.3 Release] Branch:master, Tag:1.1.3, Env:production

### DIFF
--- a/packages/scripts-context/CHANGELOG.md
+++ b/packages/scripts-context/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @qlover/scripts-context
 
+## 1.1.3
+
+### Patch Changes
+
+#### 🐞 Bug Fixes
+
+- **ScriptContext:** streamline environment option retrieval in getDefaultOptions method ([6fe72ec](https://github.com/qlover/fe-base/commit/6fe72ecf2d4d0414fa3c2b07549f4e6c4b6d91e2)) ([#495](https://github.com/qlover/fe-base/pull/495))
+  - Updated the getDefaultOptions method to simplify the logic for retrieving the environment variable. The environment is now set directly from this.options.env or fetched using Env.searchEnv if not provided, improving code clarity and maintainability.
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/scripts-context/package.json
+++ b/packages/scripts-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/scripts-context",
   "description": "A scripts context for frontwork",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/scripts-context#readme",


### PR DESCRIPTION
## Publish Details

- 🏷️ Version: 1.1.3
- 🌲 Branch: master
- 🔧 Environment: production

## Changelog

#### 🐞 Bug Fixes

- **ScriptContext:** streamline environment option retrieval in getDefaultOptions method ([6fe72ec](https://github.com/qlover/fe-base/commit/6fe72ecf2d4d0414fa3c2b07549f4e6c4b6d91e2)) ([#495](https://github.com/qlover/fe-base/pull/495))
    
    
    - Updated the getDefaultOptions method to simplify the logic for retrieving the environment variable. The environment is now set directly from this.options.env or fetched using Env.searchEnv if not provided, improving code clarity and maintainability.

## Notes

- [ ] Please check if the version number is correct
- [ ] Please confirm all tests have passed
- [ ] Please confirm the documentation has been updated

> This PR is auto created by release process, please contact the frontend team if there are any questions.