### PR TITLE
refactor(create-app): structure and update entry points

### DIFF
--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -1,0 +1,54 @@
+import { resolve } from 'path';
+import { existsSync } from 'fs';
+import { Command } from 'commander';
+import { Generator } from './Generator';
+import pkg from '../package.json';
+
+function programArgs() {
+  const program = new Command();
+
+  program
+    .version(pkg.version, '-v, --version', 'Show version')
+    .description(pkg.description)
+    .option(
+      '-d, --dry-run',
+      'Do not touch or write anything, but show the commands'
+    )
+    .option('-V, --verbose', 'Show more information')
+    .option('--config', 'Copy config files (default: true)', true)
+    .option('--no-config', 'Do not copy config files');
+
+  // parse arguments
+  program.parse();
+
+  return program.opts();
+}
+
+export async function main(rootPath: string = process.cwd()) {
+  const { dryRun, verbose, ...commandOptions } = programArgs();
+
+  const templateRootPath = resolve(rootPath, './templates');
+  const configsRootPath = resolve(rootPath, './configs');
+
+  if (!existsSync(templateRootPath)) {
+    console.error('Template is empty!');
+    process.exit(1);
+  }
+
+  if (!existsSync(configsRootPath)) {
+    console.error('Configs is empty!');
+    process.exit(1);
+  }
+
+  const generator = new Generator({
+    dryRun,
+    verbose,
+    options: {
+      ...commandOptions,
+      templateRootPath,
+      configsRootPath
+    }
+  });
+
+  await generator.generate();
+}

--- a/packages/create-app/src/index.mts
+++ b/packages/create-app/src/index.mts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+import { main } from './cli';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+main(__dirname).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -1,61 +1,8 @@
 #!/usr/bin/env node
 
-import { resolve } from 'path';
-import { existsSync } from 'fs';
-import { Command } from 'commander';
-import { Generator } from './Generator';
-import pkg from '../package.json';
+import { main } from './cli.js';
 
-function programArgs() {
-  const program = new Command();
-
-  program
-    .version(pkg.version, '-v, --version', 'Show version')
-    .description(pkg.description)
-    .option(
-      '-d, --dry-run',
-      'Do not touch or write anything, but show the commands'
-    )
-    .option('-V, --verbose', 'Show more information')
-    .option('--config', 'Copy config files (default: true)', true)
-    .option('--no-config', 'Do not copy config files');
-
-  // parse arguments
-  program.parse();
-
-  return program.opts();
-}
-
-async function main() {
-  const { dryRun, verbose, ...commandOptions } = programArgs();
-
-  const templateRootPath = resolve('./templates');
-  const configsRootPath = resolve('./configs');
-
-  if (!existsSync(templateRootPath)) {
-    console.error('Template is empty!');
-    process.exit(1);
-  }
-
-  if (!existsSync(configsRootPath)) {
-    console.error('Configs is empty!');
-    process.exit(1);
-  }
-
-  const generator = new Generator({
-    dryRun,
-    verbose,
-    options: {
-      ...commandOptions,
-      templateRootPath,
-      configsRootPath
-    }
-  });
-
-  await generator.generate();
-}
-
-main().catch((err) => {
+main(__dirname).catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/packages/create-app/tsup.config.ts
+++ b/packages/create-app/tsup.config.ts
@@ -20,7 +20,7 @@ export default defineConfig([
     platform: 'node'
   },
   {
-    entry: ['src/index.ts'],
+    entry: ['src/index.mts'],
     format: 'esm',
     minify: true,
     dts: true,


### PR DESCRIPTION
- Changed the entry point in tsup.config.ts from 'src/index.ts' to 'src/index.mts' for better module support.
- Introduced a new CLI interface in src/cli.ts to handle command-line arguments and application logic.
- Created a new entry file src/index.mts that imports and executes the main function from the CLI, enhancing modularity and clarity.
- Removed the old main function from src/index.ts, streamlining the codebase and improving maintainability.

These changes aim to improve the application's structure and facilitate better command-line interactions.