### PR TITLE
chore: bump package versions for next-oauth-wrapper, next-seed, react…

### DIFF
--- a/examples/next-oauth-wrapper/package.json
+++ b/examples/next-oauth-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-oauth-wrapper",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "dev": "cross-env APP_ENV=localhost next dev --port 3120",

--- a/examples/next-seed/package.json
+++ b/examples/next-seed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-seed",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "cross-env APP_ENV=localhost next dev --port 3100",

--- a/examples/react-seed/package.json
+++ b/examples/react-seed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples/react-seed",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite --mode localhost",

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlover/create-app",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Create a new app with a single command",
   "private": false,
   "type": "module",


### PR DESCRIPTION
…-seed, and create-app examples

- Updated version numbers in `package.json` files to reflect new releases:
  - next-oauth-wrapper: 0.0.1 to 0.0.2
  - next-seed: 1.2.0 to 1.2.1
  - react-seed: 1.1.0 to 1.1.1
  - create-app: 3.1.0 to 3.1.1

These updates ensure that all examples are aligned with their latest versions, improving overall project consistency and maintainability.