### PR TITLE
[batch-@qlover/corekit-bridge@3.2.1_@qlover/oauth-wrapper@0.2.1_examples/next-oauth-wrapper@0.1.1-5-packages-1780537707743 Release] Branch:master, Tag:batch-5-packages-1780537707743, Env:development

### DIFF
--- a/examples/next-oauth-wrapper/CHANGELOG.md
+++ b/examples/next-oauth-wrapper/CHANGELOG.md
@@ -1,5 +1,34 @@
 # examples/next-oauth-wrapper
 
+## 0.1.1
+
+### Patch Changes
+
+#### ✨ Features
+
+- **next-oauth-wrapper:** implement Supabase OAuth adapter and provider ([97b0ebd](https://github.com/qlover/fe-base/commit/97b0ebdee2f2ce4be0d1c821e6f08112f27824f9)) ([#618](https://github.com/qlover/fe-base/pull/618))
+  - Added `SupabaseOAuthAdapter` and `SupabaseOAuthProvider` to handle OAuth authentication with Supabase, including user login and session management.
+  - Updated `.env.template` to include a new `OAUTH_SESSION_KEY` for session management.
+  - Refactored the `LoginForm` and other components to utilize the new `AppUserGateway` for user authentication, replacing the previous `OAuthWrapperGateway`.
+  - Adjusted local server ports in `package.json` and related files from 3120 to 3200 for consistency across the development environment.
+  - Enhanced error handling and user feedback in the authentication process, improving overall user experience.
+  - Cleaned up unused imports and refactored code for better organization and clarity.
+
+- **next-oauth-wrapper:** add shared Tailwind styles and refactor imports ([41236fd](https://github.com/qlover/fe-base/commit/41236fddd553f68177d918e13d84763241a32cee)) ([#618](https://github.com/qlover/fe-base/pull/618))
+  - Introduced a new `component.ts` file containing shared Tailwind class strings for the OAuth UI, enhancing consistency in styling across components.
+  - Refactored various components to import the new shared styles from `@config/component`, replacing previous local imports for improved organization.
+  - Removed the now redundant `headerStyles.ts` file, streamlining the codebase.
+  - Updated type definitions in `AppRoutePage` to enhance clarity and maintainability.
+
+#### ♻️ Refactors
+
+- **oauth-wrapper:** change userId and ownerUserId types to string in database schemas and related services ([e1cccd9](https://github.com/qlover/fe-base/commit/e1cccd9925690c81a42670af0d5fcbe45be1d0fc)) ([#618](https://github.com/qlover/fe-base/pull/618))
+  - Updated the `userId` and `ownerUserId` fields in the SQL schemas to use `text` instead of `integer` for better compatibility with string-based identifiers.
+  - Adjusted related service methods and interfaces to reflect the new string type, ensuring consistency across the OAuth wrapper implementation.
+  - Introduced a new `NextApiHandler` class for improved result handling in API responses, replacing the deprecated `ApiResultFactory`.
+  - Enhanced the `NextApiServer` class to utilize the new result handler for processing API results and managing response contexts.
+  - Refactored various controllers and services to align with the updated user ID type and new result handling approach, improving code clarity and maintainability.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/examples/next-oauth-wrapper/package.json
+++ b/examples/next-oauth-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-oauth-wrapper",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "cross-env APP_ENV=localhost next dev --port 3200",

--- a/examples/next-seed/CHANGELOG.md
+++ b/examples/next-seed/CHANGELOG.md
@@ -1,5 +1,9 @@
 # examples/next-seed
 
+## 1.2.3
+
+### Patch Changes
+
 ## 1.2.2
 
 ### Patch Changes

--- a/examples/next-seed/package.json
+++ b/examples/next-seed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-seed",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "scripts": {
     "dev": "cross-env APP_ENV=localhost next dev --port 3010",

--- a/examples/react-seed/CHANGELOG.md
+++ b/examples/react-seed/CHANGELOG.md
@@ -1,5 +1,23 @@
 # examples/react-seed
 
+## 1.2.1
+
+### Patch Changes
+
+#### ✨ Features
+
+- **next-oauth-wrapper:** add shared Tailwind styles and refactor imports ([41236fd](https://github.com/qlover/fe-base/commit/41236fddd553f68177d918e13d84763241a32cee)) ([#618](https://github.com/qlover/fe-base/pull/618))
+  - Introduced a new `component.ts` file containing shared Tailwind class strings for the OAuth UI, enhancing consistency in styling across components.
+  - Refactored various components to import the new shared styles from `@config/component`, replacing previous local imports for improved organization.
+  - Removed the now redundant `headerStyles.ts` file, streamlining the codebase.
+  - Updated type definitions in `AppRoutePage` to enhance clarity and maintainability.
+
+#### 🐞 Bug Fixes
+
+- **react-seed:** update OAuth URL and refactor user service usage ([6ebf0bf](https://github.com/qlover/fe-base/commit/6ebf0bfaf8baecfcd903dbac37dd772b3f8c05f8)) ([#618](https://github.com/qlover/fe-base/pull/618))
+  - Changed the OAuth URL in `.env.template` from `http://localhost:3120` to `http://localhost:3200` for updated local server configuration.
+  - Refactored the `Login.tsx` file to remove unnecessary type casting when using the `UserService`, improving code clarity and type safety.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/examples/react-seed/package.json
+++ b/examples/react-seed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples/react-seed",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite --mode localhost",

--- a/packages/corekit-bridge/CHANGELOG.md
+++ b/packages/corekit-bridge/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @qlover/corekit-bridge
 
+## 3.2.1
+
+### Patch Changes
+
+#### ✨ Features
+
+- **corekit-bridge:** add LocaleRouter for locale management in URLs ([3cf201c](https://github.com/qlover/fe-base/commit/3cf201c52cef59fb6597b093ff23a89491737ce5)) ([#618](https://github.com/qlover/fe-base/pull/618))
+  - Introduced the `LocaleRouter` class to handle locale switching in URLs, supporting both path and query modes.
+  - Added comprehensive unit tests for the `LocaleRouter` to cover various edge cases and ensure robust functionality.
+  - Updated `package.json` to include new URL helper module and exported it from the core index.
+  - Created a new test file for `LocaleRouter` to validate its behavior across different scenarios.
+
 ## 3.2.0
 
 ### Minor Changes

--- a/packages/corekit-bridge/package.json
+++ b/packages/corekit-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/corekit-bridge",
   "description": "fe-corekit Abstraction tool bridge for real development environments",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": false,
   "type": "module",
   "sideEffects": false,

--- a/packages/oauth-wrapper/CHANGELOG.md
+++ b/packages/oauth-wrapper/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.1
+
+### Patch Changes
+
+#### ♻️ Refactors
+
+- **oauth-wrapper:** change userId type from number to string across interfaces and schemas ([bfe85fa](https://github.com/qlover/fe-base/commit/bfe85fa6e82561164a936dca7e8a9d8e1ca6b7e3)) ([#618](https://github.com/qlover/fe-base/pull/618))
+  - Updated the `ownerUserId` and `userId` parameters in various interfaces and schemas to use `string` instead of `number` for better compatibility with string-based identifiers.
+  - Adjusted related service methods to reflect the new type, ensuring consistency across the OAuth wrapper implementation.
+  - Enhanced the `OAuthClientRowSchema` and other schemas to align with the updated user ID type, improving data validation and integrity.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/oauth-wrapper/package.json
+++ b/packages/oauth-wrapper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/oauth-wrapper",
   "description": "Provider-agnostic OAuth 2.0 authorization server core (authorization code, PKCE, token exchange, userinfo)",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "private": false,
   "sideEffects": false,


### PR DESCRIPTION
## Publish Details

- 🏷️ Version: @qlover/corekit-bridge@3.2.1 @qlover/oauth-wrapper@0.2.1 examples/next-oauth-wrapper@0.1.1 examples/next-seed@1.2.3 examples/react-seed@1.2.1
- 🌲 Branch: master
- 🔧 Environment: development

## Changelog


## @qlover/corekit-bridge 3.2.1
#### ✨ Features

- **corekit-bridge:** add LocaleRouter for locale management in URLs ([3cf201c](https://github.com/qlover/fe-base/commit/3cf201c52cef59fb6597b093ff23a89491737ce5)) ([#618](https://github.com/qlover/fe-base/pull/618))
    
    
    - Introduced the `LocaleRouter` class to handle locale switching in URLs, supporting both path and query modes.
    - Added comprehensive unit tests for the `LocaleRouter` to cover various edge cases and ensure robust functionality.
    - Updated `package.json` to include new URL helper module and exported it from the core index.
    - Created a new test file for `LocaleRouter` to validate its behavior across different scenarios.


## @qlover/oauth-wrapper 0.2.1
#### ♻️ Refactors

- **oauth-wrapper:** change userId type from number to string across interfaces and schemas ([bfe85fa](https://github.com/qlover/fe-base/commit/bfe85fa6e82561164a936dca7e8a9d8e1ca6b7e3)) ([#618](https://github.com/qlover/fe-base/pull/618))
    
    
    - Updated the `ownerUserId` and `userId` parameters in various interfaces and schemas to use `string` instead of `number` for better compatibility with string-based identifiers.
    - Adjusted related service methods to reflect the new type, ensuring consistency across the OAuth wrapper implementation.
    - Enhanced the `OAuthClientRowSchema` and other schemas to align with the updated user ID type, improving data validation and integrity.


## examples/next-oauth-wrapper 0.1.1
#### ✨ Features

- **next-oauth-wrapper:** implement Supabase OAuth adapter and provider ([97b0ebd](https://github.com/qlover/fe-base/commit/97b0ebdee2f2ce4be0d1c821e6f08112f27824f9)) ([#618](https://github.com/qlover/fe-base/pull/618))
    
    
    - Added `SupabaseOAuthAdapter` and `SupabaseOAuthProvider` to handle OAuth authentication with Supabase, including user login and session management.
    - Updated `.env.template` to include a new `OAUTH_SESSION_KEY` for session management.
    - Refactored the `LoginForm` and other components to utilize the new `AppUserGateway` for user authentication, replacing the previous `OAuthWrapperGateway`.
    - Adjusted local server ports in `package.json` and related files from 3120 to 3200 for consistency across the development environment.
    - Enhanced error handling and user feedback in the authentication process, improving overall user experience.
    - Cleaned up unused imports and refactored code for better organization and clarity.

- **next-oauth-wrapper:** add shared Tailwind styles and refactor imports ([41236fd](https://github.com/qlover/fe-base/commit/41236fddd553f68177d918e13d84763241a32cee)) ([#618](https://github.com/qlover/fe-base/pull/618))
    
    
    - Introduced a new `component.ts` file containing shared Tailwind class strings for the OAuth UI, enhancing consistency in styling across components.
    - Refactored various components to import the new shared styles from `@config/component`, replacing previous local imports for improved organization.
    - Removed the now redundant `headerStyles.ts` file, streamlining the codebase.
    - Updated type definitions in `AppRoutePage` to enhance clarity and maintainability.
#### ♻️ Refactors

- **oauth-wrapper:** change userId and ownerUserId types to string in database schemas and related services ([e1cccd9](https://github.com/qlover/fe-base/commit/e1cccd9925690c81a42670af0d5fcbe45be1d0fc)) ([#618](https://github.com/qlover/fe-base/pull/618))
    
    
    - Updated the `userId` and `ownerUserId` fields in the SQL schemas to use `text` instead of `integer` for better compatibility with string-based identifiers.
    - Adjusted related service methods and interfaces to reflect the new string type, ensuring consistency across the OAuth wrapper implementation.
    - Introduced a new `NextApiHandler` class for improved result handling in API responses, replacing the deprecated `ApiResultFactory`.
    - Enhanced the `NextApiServer` class to utilize the new result handler for processing API results and managing response contexts.
    - Refactored various controllers and services to align with the updated user ID type and new result handling approach, improving code clarity and maintainability.


## examples/next-seed 1.2.3



## examples/react-seed 1.2.1
#### ✨ Features

- **next-oauth-wrapper:** add shared Tailwind styles and refactor imports ([41236fd](https://github.com/qlover/fe-base/commit/41236fddd553f68177d918e13d84763241a32cee)) ([#618](https://github.com/qlover/fe-base/pull/618))
    
    
    - Introduced a new `component.ts` file containing shared Tailwind class strings for the OAuth UI, enhancing consistency in styling across components.
    - Refactored various components to import the new shared styles from `@config/component`, replacing previous local imports for improved organization.
    - Removed the now redundant `headerStyles.ts` file, streamlining the codebase.
    - Updated type definitions in `AppRoutePage` to enhance clarity and maintainability.
#### 🐞 Bug Fixes

- **react-seed:** update OAuth URL and refactor user service usage ([6ebf0bf](https://github.com/qlover/fe-base/commit/6ebf0bfaf8baecfcd903dbac37dd772b3f8c05f8)) ([#618](https://github.com/qlover/fe-base/pull/618))
    
    
    - Changed the OAuth URL in `.env.template` from `http://localhost:3120` to `http://localhost:3200` for updated local server configuration.
    - Refactored the `Login.tsx` file to remove unnecessary type casting when using the `UserService`, improving code clarity and type safety.


## Notes

- [ ] Please check if the version number is correct
- [ ] Please confirm all tests have passed
- [ ] Please confirm the documentation has been updated

> This PR is auto created by release process, please contact the frontend team if there are any questions.