### PR TITLE
fix(fe-release): detect changed packages after merge to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,18 @@ jobs:
       - run: pnpm rebuild
 
       - name: Create release PR to master
+        if: github.event_name == 'pull_request'
+        run: |
+          node packages/fe-release/dist/cli.js -V \
+            -s master \
+            --workspaces.compare-ref "${{ github.event.pull_request.base.sha }}" \
+            --changesetVersion.ignore-non-updated-packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          FE_RELEASE_BRANCH: master
+
+      - name: Create release PR to master (manual)
+        if: github.event_name == 'workflow_dispatch'
         run: |
           node packages/fe-release/dist/cli.js -V \
             -s master \

--- a/packages/fe-release/__tests__/plugins/Workspace.test.ts
+++ b/packages/fe-release/__tests__/plugins/Workspace.test.ts
@@ -102,7 +102,7 @@ describe('Workspaces Plugin', () => {
   });
 
   describe('getGitWorkspaces', () => {
-    it('should return git diff result', async () => {
+    it('should return git diff result against origin/sourceBranch by default', async () => {
       // @ts-expect-error call private method for testing
       const result = await workspaces.getGitWorkspaces();
 
@@ -110,7 +110,22 @@ describe('Workspaces Plugin', () => {
         'packages/package-a/index.ts',
         'packages/package-b/package.json'
       ]);
-      expect(workspaces.shell.exec).toHaveBeenCalled();
+      expect(workspaces.shell.exec).toHaveBeenCalledWith(
+        'git diff --name-only origin/master...HEAD',
+        { dryRun: false }
+      );
+    });
+
+    it('should use workspaces.compareRef when provided', async () => {
+      workspaces.setConfig({ compareRef: 'abc1234' });
+
+      // @ts-expect-error call private method for testing
+      await workspaces.getGitWorkspaces();
+
+      expect(workspaces.shell.exec).toHaveBeenCalledWith(
+        'git diff --name-only abc1234...HEAD',
+        { dryRun: false }
+      );
     });
 
     it('when shell.exec returns non-string, should return empty array', async () => {

--- a/packages/fe-release/src/cli.ts
+++ b/packages/fe-release/src/cli.ts
@@ -230,6 +230,10 @@ function programArgs() {
       splitWithComma
     )
     .option(
+      '--workspaces.compare-ref <compareRef>',
+      'Left side of git diff <compareRef>...HEAD for changed packages (default: origin/<sourceBranch>; use PR base.sha after merge-to-master)'
+    )
+    .option(
       '-l, --workspaces.change-labels <changeLabels>',
       'Change labels used to detect changed packages, comma-separated',
       splitWithComma

--- a/packages/fe-release/src/plugins/Workspaces.ts
+++ b/packages/fe-release/src/plugins/Workspaces.ts
@@ -157,6 +157,19 @@ export interface WorkspacesProps extends ScriptPluginProps {
   packagesDirectories?: string[];
 
   /**
+   * Git ref used as the left side of `git diff <compareRef>...HEAD`
+   * when detecting changed packages.
+   *
+   * Defaults to `origin/<sourceBranch>`. After a feature PR merges into
+   * `master`, that default is empty (HEAD already is master) — pass the PR
+   * base SHA instead (e.g. `github.event.pull_request.base.sha` in CI).
+   *
+   * @optional
+   * @example `'abc1234'` or `'origin/master'`
+   */
+  compareRef?: string;
+
+  /**
    * Template for package change labels in monorepos
    *
    * Core concept:
@@ -424,10 +437,13 @@ export default class Workspaces extends ScriptPlugin<
   }
 
   protected async getGitWorkspaces(): Promise<string[]> {
-    const sourceBranch = this.context.sourceBranch;
+    const compareRef =
+      this.config.compareRef || `origin/${this.context.sourceBranch}`;
+
+    this.logger.debug(`git diff --name-only ${compareRef}...HEAD`);
 
     const result = await this.shell.exec(
-      `git diff --name-only origin/${sourceBranch}...HEAD`,
+      `git diff --name-only ${compareRef}...HEAD`,
       { dryRun: false }
     );
 


### PR DESCRIPTION
## Summary
- After a feature PR with `CI-Release` merges into `master`, `git diff origin/master...HEAD` is empty because HEAD already is master.
- Add `--workspaces.compare-ref` so CI can pass `github.event.pull_request.base.sha` as the left side of the diff.
- Split create-release-pr steps: PR-triggered uses compare-ref; `workflow_dispatch` keeps the previous behavior.

## Test plan
- [ ] Merge a feature PR into `master` with `CI-Release` and confirm `create-release-pr` finds changed packages (not 0).
- [ ] Confirm a release PR (`release/*` → `master`) is opened with expected version/changelog updates.
- [ ] Optionally run `vitest` for `packages/fe-release/__tests__/plugins/Workspace.test.ts`.