### PR TITLE
fix(fe-release): honor increment:* labels on release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,16 @@ jobs:
       - name: Create release PR to master
         if: github.event_name == 'pull_request'
         run: |
+          INCREMENT=patch
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'increment:major') }}" == "true" ]]; then
+            INCREMENT=major
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'increment:minor') }}" == "true" ]]; then
+            INCREMENT=minor
+          fi
+          echo "Using version increment: $INCREMENT"
           node packages/fe-release/dist/cli.js -V \
             -s master \
+            -i "$INCREMENT" \
             --workspaces.compare-ref "${{ github.event.pull_request.base.sha }}" \
             --changesetVersion.ignore-non-updated-packages
         env:

--- a/packages/fe-release/__tests__/plugins/ChangesetVersion.test.ts
+++ b/packages/fe-release/__tests__/plugins/ChangesetVersion.test.ts
@@ -62,6 +62,33 @@ describe('ChangesetVersion Plugin', () => {
       });
       expect(plugin.getIncrement()).toBe('major');
     });
+
+    it('should read increment label from GITHUB_EVENT_PATH', () => {
+      const eventPath = join(process.cwd(), '.tmp-github-event.json');
+      vi.mocked(existsSync).mockImplementation((path) => path === eventPath);
+      vi.mocked(readFileSync).mockImplementation((path) => {
+        if (path === eventPath) {
+          return JSON.stringify({
+            pull_request: {
+              labels: [{ name: 'CI-Release' }, { name: 'increment:major' }]
+            }
+          });
+        }
+        return JSON.stringify({ changelog: ['@changesets/cli/changelog'] });
+      });
+
+      const previous = process.env.GITHUB_EVENT_PATH;
+      process.env.GITHUB_EVENT_PATH = eventPath;
+      try {
+        expect(plugin.getIncrement()).toBe('major');
+      } finally {
+        if (previous === undefined) {
+          delete process.env.GITHUB_EVENT_PATH;
+        } else {
+          process.env.GITHUB_EVENT_PATH = previous;
+        }
+      }
+    });
   });
 
   describe('mergeWorkspaces', () => {

--- a/packages/fe-release/src/plugins/ChangesetVersion.ts
+++ b/packages/fe-release/src/plugins/ChangesetVersion.ts
@@ -588,16 +588,18 @@ export default class ChangesetVersion extends ScriptPlugin<
   }
 
   public getIncrement(): string {
-    const labels = this.context.parameters.workspaces?.changeLabels;
+    const labels = this.getIncrementLabels();
 
-    if (Array.isArray(labels) && labels.length > 0) {
-      if (labels.includes('increment:major')) {
-        return 'major';
-      }
+    if (labels.includes('increment:major')) {
+      return 'major';
+    }
 
-      if (labels.includes('increment:minor')) {
-        return 'minor';
-      }
+    if (labels.includes('increment:minor')) {
+      return 'minor';
+    }
+
+    if (labels.includes('increment:patch')) {
+      return 'patch';
     }
 
     return (
@@ -605,6 +607,45 @@ export default class ChangesetVersion extends ScriptPlugin<
       this.context.parameters.changesetVersion?.increment ||
       releaseJson.changesetVersion.increment
     );
+  }
+
+  /**
+   * Labels that can override semver increment.
+   *
+   * Prefer explicit `workspaces.changeLabels`, then fall back to the PR labels
+   * from `GITHUB_EVENT_PATH` when running in GitHub Actions after a PR merge.
+   */
+  protected getIncrementLabels(): string[] {
+    const fromConfig = this.context.parameters.workspaces?.changeLabels;
+    if (Array.isArray(fromConfig) && fromConfig.length > 0) {
+      return fromConfig.filter((label): label is string => typeof label === 'string');
+    }
+
+    return this.readGithubEventLabelNames();
+  }
+
+  protected readGithubEventLabelNames(): string[] {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath || !existsSync(eventPath)) {
+      return [];
+    }
+
+    try {
+      const event = JSON.parse(readFileSync(eventPath, 'utf8')) as {
+        pull_request?: { labels?: Array<{ name?: string }> };
+      };
+      const labels = event.pull_request?.labels;
+      if (!Array.isArray(labels)) {
+        return [];
+      }
+
+      return labels
+        .map((label) => label?.name)
+        .filter((name): name is string => typeof name === 'string' && name.length > 0);
+    } catch (error) {
+      this.logger.debug('Failed to read labels from GITHUB_EVENT_PATH', error);
+      return [];
+    }
   }
 
   public async generateChangesetFile(

--- a/packages/scripts-context/package.json
+++ b/packages/scripts-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/scripts-context",
   "description": "A scripts context for frontwork",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/scripts-context#readme",


### PR DESCRIPTION
## Summary
- After switching changed-package detection to git diff, CI stopped forwarding PR labels, so `increment:major` / `increment:minor` were ignored and bumps always used `patch`.
- `ChangesetVersion.getIncrement()` now reads `increment:*` from `GITHUB_EVENT_PATH` PR labels when `workspaces.changeLabels` is not set.
- `release.yml` also derives `-i major|minor|patch` from the merged PR labels and logs the chosen increment.

## Test plan
- [ ] Open a feature PR to `master` with `CI-Release` + `increment:major`, merge it, and confirm the release PR bumps a **major** version.
- [ ] Repeat with `increment:minor` and with no increment label (expect **patch**).
- [ ] Check create-release-pr logs for `Using version increment: ...`.
- [ ] `pnpm exec vitest run packages/fe-release/__tests__/plugins/ChangesetVersion.test.ts`