### PR TITLE
Release development fe-base release-tag-2-patch-50dad159c2f7409f

### DIFF
--- a/packages/fe-release/CHANGELOG.md
+++ b/packages/fe-release/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @qlover/fe-release
 
+## 5.0.0
+
+### Major Changes
+
+#### 🐞 Bug Fixes
+
+- **fe-release:** honor increment:\* labels on release PRs ([7e03012](https://github.com/qlover/fe-base/commit/7e0301208317380d0aff9b56870311ce0bf71835)) ([#642](https://github.com/qlover/fe-base/pull/642))
+
+- **fe-release:** detect changed packages after merge to master ([e25b6ad](https://github.com/qlover/fe-base/commit/e25b6adeee3cebed8610f8393952aca942d94c32)) ([#640](https://github.com/qlover/fe-base/pull/640))
+
+#### ♻️ Refactors
+
+- **fe-release:** consolidate release pipeline and fix dependency-release changelog handling ([3e19ab6](https://github.com/qlover/fe-base/commit/3e19ab6f5e5af61609aa998757b54ce2701e8579)) ([#639](https://github.com/qlover/fe-base/pull/639))
+
+- **fe-release:** improve test readability in ReleaseFormatter tests ([72f09be](https://github.com/qlover/fe-base/commit/72f09be48ae1a6e5c799ae33761a54d0ae5fb7e4)) ([#639](https://github.com/qlover/fe-base/pull/639))
+
+### Patch Changes
+
+- Update dependency **@qlover/scripts-context** from `2.2.1` to `3.0.0`
+
 ## 4.3.0
 
 ### Minor Changes

--- a/packages/fe-release/CHANGELOG.md
+++ b/packages/fe-release/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Patch Changes
 
-- Update dependency **@qlover/scripts-context** from `2.2.1` to `3.0.0`
+- Update dependency **@qlover/scripts-context** from `2.2.1` to `2.3.0`
 
 ## 4.3.0
 

--- a/packages/fe-release/package.json
+++ b/packages/fe-release/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/fe-release",
   "description": "A tool for releasing front-end projects, supporting multiple release modes and configurations, simplifying the release process and improving efficiency.",
-  "version": "4.3.1",
+  "version": "5.0.0",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/fe-release",

--- a/packages/scripts-context/CHANGELOG.md
+++ b/packages/scripts-context/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @qlover/scripts-context
 
+## 3.0.0
+
+### Major Changes
+
+#### ♻️ Refactors
+
+- **fe-release:** consolidate release pipeline and fix dependency-release changelog handling ([3e19ab6](https://github.com/qlover/fe-base/commit/3e19ab6f5e5af61609aa998757b54ce2701e8579)) ([#639](https://github.com/qlover/fe-base/pull/639))
+
 ## 2.2.0
 
 ### Minor Changes

--- a/packages/scripts-context/CHANGELOG.md
+++ b/packages/scripts-context/CHANGELOG.md
@@ -1,8 +1,8 @@
 # @qlover/scripts-context
 
-## 3.0.0
+## 2.3.0
 
-### Major Changes
+### Minor Changes
 
 #### ♻️ Refactors
 

--- a/packages/scripts-context/package.json
+++ b/packages/scripts-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/scripts-context",
   "description": "A scripts context for frontwork",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/scripts-context#readme",

--- a/packages/scripts-context/package.json
+++ b/packages/scripts-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/scripts-context",
   "description": "A scripts context for frontwork",
-  "version": "3.0.0",
+  "version": "2.3.0",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/scripts-context#readme",


### PR DESCRIPTION
## Changelog


## @qlover/fe-release 5.0.0

#### 🐞 Bug Fixes

- **fe-release:** honor increment:* labels on release PRs ([7e03012](https://github.com/qlover/fe-base/commit/7e0301208317380d0aff9b56870311ce0bf71835)) ([#642](https://github.com/qlover/fe-base/pull/642))

- **fe-release:** detect changed packages after merge to master ([e25b6ad](https://github.com/qlover/fe-base/commit/e25b6adeee3cebed8610f8393952aca942d94c32)) ([#640](https://github.com/qlover/fe-base/pull/640))
#### ♻️ Refactors

- **fe-release:** consolidate release pipeline and fix dependency-release changelog handling ([3e19ab6](https://github.com/qlover/fe-base/commit/3e19ab6f5e5af61609aa998757b54ce2701e8579)) ([#639](https://github.com/qlover/fe-base/pull/639))

- **fe-release:** improve test readability in ReleaseFormatter tests ([72f09be](https://github.com/qlover/fe-base/commit/72f09be48ae1a6e5c799ae33761a54d0ae5fb7e4)) ([#639](https://github.com/qlover/fe-base/pull/639))


## @qlover/scripts-context 2.3.0
#### ♻️ Refactors

- **fe-release:** consolidate release pipeline and fix dependency-release changelog handling ([3e19ab6](https://github.com/qlover/fe-base/commit/3e19ab6f5e5af61609aa998757b54ce2701e8579)) ([#639](https://github.com/qlover/fe-base/pull/639))
