### PR TITLE
fix(fe-release): fix master-only release PR metadata and publish package detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,8 +143,11 @@ jobs:
       - name: Create tag and publish
         run: |
           node packages/fe-release/dist/cli.js -V \
+            --workspaces.compare-ref "${{ github.event.pull_request.base.sha }}" \
             --changesetVersion.skip-changeset \
-            --changesetVersion.mode publish
+            --changesetVersion.mode publish \
+            --github.skip
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          FE_RELEASE_BRANCH: master

--- a/packages/fe-release/__tests__/implements/ReleaseFormatter.test.ts
+++ b/packages/fe-release/__tests__/implements/ReleaseFormatter.test.ts
@@ -90,9 +90,9 @@ describe('ReleaseFormatter', () => {
     );
 
     expect(body).toContain('pkg-a@1.0.1 pkg-b@2.1.0');
-    expect(body).toContain('## pkg-a 1.0.0');
+    expect(body).toContain('## pkg-a 1.0.1');
     expect(body).toContain('- feat: add feature');
-    expect(body).toContain('## pkg-b 2.0.0');
+    expect(body).toContain('## pkg-b 2.1.0');
     expect(body).toContain('- fix: bug');
   });
 

--- a/packages/fe-release/__tests__/plugins/ChangesetVersion.test.ts
+++ b/packages/fe-release/__tests__/plugins/ChangesetVersion.test.ts
@@ -164,6 +164,50 @@ describe('ChangesetVersion Plugin', () => {
     });
   });
 
+  describe('syncWorkspaces', () => {
+    it('should drop dependency-release workspaces when ignoreNonUpdatedPackages', () => {
+      plugin.setConfig({ ignoreNonUpdatedPackages: true });
+      vi.spyOn(
+        createWorkspaceModule,
+        'readWorkspacePackageFromDisk'
+      ).mockImplementation(({ path }) => {
+        const isA = String(path).includes('packages/a');
+        return {
+          root: isA ? '/repo/packages/a' : '/repo/packages/b',
+          packagePath: isA
+            ? '/repo/packages/a/package.json'
+            : '/repo/packages/b/package.json',
+          manifestPath: 'package.json',
+          version: isA ? '1.0.1' : '2.0.0',
+          packageJson: {
+            name: isA ? 'pkg-a' : 'pkg-b',
+            version: isA ? '1.0.1' : '2.0.0'
+          }
+        };
+      });
+
+      // @ts-expect-error call protected method for testing
+      plugin.syncWorkspaces([
+        workspace,
+        {
+          ...workspace,
+          name: 'pkg-b',
+          path: 'packages/b',
+          root: '/repo/packages/b',
+          packageJson: { name: 'pkg-b', version: '2.0.0' },
+          dependencyRelease: true,
+          dependencyReleaseOf: 'pkg-a',
+          changelog: '- Update dependency pkg-a'
+        }
+      ]);
+
+      const result = context.workspaces ?? [];
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('pkg-a');
+      expect(result[0].dependencyRelease).toBeFalsy();
+    });
+  });
+
   describe('generateChangesetFile', () => {
     it('should skip dependency-release workspaces', async () => {
       const writeSpy = vi.mocked(writeFileSync);

--- a/packages/fe-release/__tests__/plugins/Workspace.test.ts
+++ b/packages/fe-release/__tests__/plugins/Workspace.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'node:path';
 import Workspaces from '../../src/plugins/Workspaces';
 import * as createWorkspaceModule from '../../src/utils/createWorkspace';
 import { WorkspaceValue } from '../../src/implments/WorkspaceValue';
@@ -126,6 +127,41 @@ describe('Workspaces Plugin', () => {
         'git diff --name-only abc1234...HEAD',
         { dryRun: false }
       );
+    });
+
+    it('should fall back to pull_request.base.sha from GITHUB_EVENT_PATH', async () => {
+      const eventPath = join(process.cwd(), '.tmp-github-pr-event.json');
+      const { writeFileSync, unlinkSync, existsSync } = await import('node:fs');
+      writeFileSync(
+        eventPath,
+        JSON.stringify({
+          pull_request: {
+            merged: true,
+            base: { sha: 'pr-base-sha-001' }
+          }
+        }),
+        'utf8'
+      );
+
+      const previous = process.env.GITHUB_EVENT_PATH;
+      process.env.GITHUB_EVENT_PATH = eventPath;
+      try {
+        // @ts-expect-error call private method for testing
+        await workspaces.getGitWorkspaces();
+        expect(workspaces.shell.exec).toHaveBeenCalledWith(
+          'git diff --name-only pr-base-sha-001...HEAD',
+          { dryRun: false }
+        );
+      } finally {
+        if (previous === undefined) {
+          delete process.env.GITHUB_EVENT_PATH;
+        } else {
+          process.env.GITHUB_EVENT_PATH = previous;
+        }
+        if (existsSync(eventPath)) {
+          unlinkSync(eventPath);
+        }
+      }
     });
 
     it('when shell.exec returns non-string, should return empty array', async () => {

--- a/packages/fe-release/src/defaults.ts
+++ b/packages/fe-release/src/defaults.ts
@@ -32,7 +32,7 @@ export const releaseJson = {
     skipCreateReleasePR: false,
     PRTitle: 'Release ${env} ${pkgName} ${tagName}',
     PRBody: '## Changelog\n\n${changelog}',
-    batchPRBody: '\n## ${name} ${version}\n${changelog}\n',
+    batchPRBody: '\n## ${name} ${newVersion}\n${changelog}\n',
     branchName: 'release/${repoName}-${releaseId}',
     releaseTagName: 'release-tag-${count}-patch-${releaseId}',
     commitMessage: 'chore(release): ${spaces}',

--- a/packages/fe-release/src/implments/ReleaseFormatter.ts
+++ b/packages/fe-release/src/implments/ReleaseFormatter.ts
@@ -323,7 +323,12 @@ export class ReleaseFormatter {
       .map((workspace) =>
         this.templateEngine.render(
           this.config.batchPRBody || releaseJson.github.batchPRBody,
-          workspace
+          {
+            ...workspace,
+            // Prefer bumped version in PR changelog section headers
+            version: workspace.newVersion || workspace.version,
+            newVersion: workspace.newVersion || workspace.version
+          }
         )
       )
       .join('\n');

--- a/packages/fe-release/src/plugins/ChangesetVersion.ts
+++ b/packages/fe-release/src/plugins/ChangesetVersion.ts
@@ -131,8 +131,8 @@ export interface ChangesetVersionProps
    * 2. **Changelog / changeset**: skip processing for `dependencyRelease` workspaces
    * 3. **`changeset version`**: runs as usual (changesets may still touch dependents)
    * 4. **Restore**: `git restore` all `dependencyRelease` workspace paths
-   * 5. **Result**: only directly changed packages remain bumped; logs show their
-   *    version changes only
+   * 5. **Result**: only directly changed packages remain bumped; they are the only
+   *    workspaces left for GitHub PR title/body/`release-tag-${count}-*` naming
    *
    * @see {@link shouldProcessWorkspace} for the per-workspace processing gate
    *
@@ -347,9 +347,18 @@ export default class ChangesetVersion extends ScriptPlugin<
   }
 
   protected syncWorkspaces(workspaces: WorkspaceInterface[]): void {
-    const newWorkspaces = this.refreshDependencyReleaseChangelogs(
-      this.mergeWorkspaces(workspaces)
-    );
+    let newWorkspaces = this.mergeWorkspaces(workspaces);
+
+    if (this.ignoreNonUpdatedPackages) {
+      // Dependents were only tracked for git restore; drop them so PR title,
+      // body, and release-tag-${count} reflect directly changed packages only.
+      newWorkspaces = newWorkspaces.filter(
+        (workspace) => !workspace.dependencyRelease
+      );
+    } else {
+      newWorkspaces = this.refreshDependencyReleaseChangelogs(newWorkspaces);
+    }
+
     const bumpedWorkspaces = newWorkspaces.filter(
       (workspace) =>
         this.shouldProcessWorkspace(workspace) &&

--- a/packages/fe-release/src/plugins/ChangesetVersion.ts
+++ b/packages/fe-release/src/plugins/ChangesetVersion.ts
@@ -239,6 +239,13 @@ export default class ChangesetVersion extends ScriptPlugin<
   }
 
   public override async onExec(_context: ReleaseContext): Promise<void> {
+    // Publish-only runs do not need generated changelogs; `changeset publish`
+    // decides what to release from package versions / tags on disk.
+    if (this.mode === 'publish') {
+      this.logger.info('Skip changelog generation in publish mode');
+      return;
+    }
+
     const workspaces = this.context.requireWorkspaces();
 
     const processableWorkspaces = this.getProcessableWorkspaces(workspaces);

--- a/packages/fe-release/src/plugins/Workspaces.ts
+++ b/packages/fe-release/src/plugins/Workspaces.ts
@@ -35,6 +35,7 @@
  * ```
  */
 import { resolve, relative, isAbsolute } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
 import type ReleaseContext from '../implments/ReleaseContext';
 import type { ReleaseLabelCompare } from '../implments/ReleaseLabel';
 import { ReleaseLabel } from '../implments/ReleaseLabel';
@@ -160,9 +161,9 @@ export interface WorkspacesProps extends ScriptPluginProps {
    * Git ref used as the left side of `git diff <compareRef>...HEAD`
    * when detecting changed packages.
    *
-   * Defaults to `origin/<sourceBranch>`. After a feature PR merges into
-   * `master`, that default is empty (HEAD already is master) — pass the PR
-   * base SHA instead (e.g. `github.event.pull_request.base.sha` in CI).
+   * Defaults to `origin/<sourceBranch>`, then falls back to the merged PR base
+   * SHA from `GITHUB_EVENT_PATH` when running after a GitHub Actions PR merge
+   * into the same branch (where `origin/<sourceBranch>...HEAD` is empty).
    *
    * @optional
    * @example `'abc1234'` or `'origin/master'`
@@ -437,8 +438,7 @@ export default class Workspaces extends ScriptPlugin<
   }
 
   protected async getGitWorkspaces(): Promise<string[]> {
-    const compareRef =
-      this.config.compareRef || `origin/${this.context.sourceBranch}`;
+    const compareRef = this.resolveCompareRef();
 
     this.logger.debug(`git diff --name-only ${compareRef}...HEAD`);
 
@@ -459,6 +459,57 @@ export default class Workspaces extends ScriptPlugin<
     this.logger.debug(`Git changed files count: ${files.length}`);
 
     return files;
+  }
+
+  /**
+   * Left side of `git diff <compareRef>...HEAD` for changed package detection.
+   *
+   * Priority:
+   * 1. Explicit `workspaces.compareRef` / `--workspaces.compare-ref`
+   * 2. Merged PR base SHA from `GITHUB_EVENT_PATH` (needed after merge-to-master,
+   *    where `origin/master...HEAD` is empty)
+   * 3. `origin/<sourceBranch>`
+   */
+  protected resolveCompareRef(): string {
+    if (this.config.compareRef) {
+      return this.config.compareRef;
+    }
+
+    const prBaseSha = this.readGithubEventBaseSha();
+    if (prBaseSha) {
+      this.logger.debug(
+        `Using pull_request.base.sha from GITHUB_EVENT_PATH as compareRef: ${prBaseSha}`
+      );
+      return prBaseSha;
+    }
+
+    return `origin/${this.context.sourceBranch}`;
+  }
+
+  protected readGithubEventBaseSha(): string | undefined {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath || !existsSync(eventPath)) {
+      return undefined;
+    }
+
+    try {
+      const event = JSON.parse(readFileSync(eventPath, 'utf8')) as {
+        pull_request?: { base?: { sha?: string }; merged?: boolean };
+      };
+
+      if (event.pull_request?.merged !== true) {
+        return undefined;
+      }
+
+      const sha = event.pull_request.base?.sha;
+      return typeof sha === 'string' && sha.length > 0 ? sha : undefined;
+    } catch (error) {
+      this.logger.debug(
+        'Failed to read pull_request.base.sha from GITHUB_EVENT_PATH',
+        error
+      );
+      return undefined;
+    }
   }
 
   protected async getChangedPackages(

--- a/packages/scripts-context/package.json
+++ b/packages/scripts-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/scripts-context",
   "description": "A scripts context for frontwork",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/scripts-context#readme",


### PR DESCRIPTION
## Summary
- Drop `dependencyRelease` workspaces after `ignore-non-updated-packages` restore, so release PR title `count` and changelog only include directly changed packages.
- Show bumped `newVersion` in batch PR section headers (was showing pre-bump `version`).
- After a release PR merges into `master`, publish no longer fails on empty `origin/master...HEAD`:
  - pass/use PR `base.sha` as `workspaces.compare-ref`
  - auto-fall back to `GITHUB_EVENT_PATH` base SHA when compare-ref is omitted
  - skip changelog generation in `changesetVersion.mode publish`
  - add `--github.skip` on publish so CI does not open another release PR

## Test plan
- [ ] Merge a `CI-Release` feature PR with packages that have internal dependents + `ignore-non-updated-packages`.
- [ ] Confirm release PR title count matches only direct packages, and section headers show new versions.
- [ ] Merge the release PR and confirm publish finds changed packages (not `Found 0 changed packages`).
- [ ] Confirm publish does not create a new release PR.
- [ ] `pnpm exec vitest run packages/fe-release/__tests__/plugins/Workspace.test.ts packages/fe-release/__tests__/plugins/ChangesetVersion.test.ts packages/fe-release/__tests__/implements/ReleaseFormatter.test.ts`