### PR TITLE
test(fe-release): isolate getGitWorkspaces default from GITHUB_EVENT_PATH

### DIFF
--- a/packages/fe-release/__tests__/plugins/Workspace.test.ts
+++ b/packages/fe-release/__tests__/plugins/Workspace.test.ts
@@ -104,17 +104,28 @@ describe('Workspaces Plugin', () => {
 
   describe('getGitWorkspaces', () => {
     it('should return git diff result against origin/sourceBranch by default', async () => {
-      // @ts-expect-error call private method for testing
-      const result = await workspaces.getGitWorkspaces();
+      const previous = process.env.GITHUB_EVENT_PATH;
+      delete process.env.GITHUB_EVENT_PATH;
 
-      expect(result).toEqual([
-        'packages/package-a/index.ts',
-        'packages/package-b/package.json'
-      ]);
-      expect(workspaces.shell.exec).toHaveBeenCalledWith(
-        'git diff --name-only origin/master...HEAD',
-        { dryRun: false }
-      );
+      try {
+        // @ts-expect-error call private method for testing
+        const result = await workspaces.getGitWorkspaces();
+
+        expect(result).toEqual([
+          'packages/package-a/index.ts',
+          'packages/package-b/package.json'
+        ]);
+        expect(workspaces.shell.exec).toHaveBeenCalledWith(
+          'git diff --name-only origin/master...HEAD',
+          { dryRun: false }
+        );
+      } finally {
+        if (previous === undefined) {
+          delete process.env.GITHUB_EVENT_PATH;
+        } else {
+          process.env.GITHUB_EVENT_PATH = previous;
+        }
+      }
     });
 
     it('should use workspaces.compareRef when provided', async () => {


### PR DESCRIPTION
CI sets GITHUB_EVENT_PATH, so the default compare-ref assertion incorrectly used the PR base SHA. Clear the env var in the default-path unit test.