### PR TITLE
Release development fe-base release-tag-1-patch-24fa302f385d465e

### DIFF
--- a/packages/fe-release/CHANGELOG.md
+++ b/packages/fe-release/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @qlover/fe-release
 
+## 5.0.1
+
+### Patch Changes
+
+#### ✨ Features
+
+- **fe-release:** enhance GitHub Actions release workflow and improve package detection ([c245fea](https://github.com/qlover/fe-base/commit/c245fea933169a0a0d363931c84b2665397e659c)) ([#644](https://github.com/qlover/fe-base/pull/644))
+
+#### 🐞 Bug Fixes
+
+- **fe-release:** exclude restored dependency packages from release PR ([ed431ab](https://github.com/qlover/fe-base/commit/ed431abdfaa449eb987a696a01fd7d8713cc43b4)) ([#644](https://github.com/qlover/fe-base/pull/644))
+
+- **fe-release:** honor increment:\* labels on release PRs ([7e03012](https://github.com/qlover/fe-base/commit/7e0301208317380d0aff9b56870311ce0bf71835)) ([#642](https://github.com/qlover/fe-base/pull/642))
+
+- **fe-release:** detect changed packages after merge to master ([e25b6ad](https://github.com/qlover/fe-base/commit/e25b6adeee3cebed8610f8393952aca942d94c32)) ([#640](https://github.com/qlover/fe-base/pull/640))
+
+#### ♻️ Refactors
+
+- **fe-release:** consolidate release pipeline and fix dependency-release changelog handling ([3e19ab6](https://github.com/qlover/fe-base/commit/3e19ab6f5e5af61609aa998757b54ce2701e8579)) ([#639](https://github.com/qlover/fe-base/pull/639))
+
+- **fe-release:** improve test readability in ReleaseFormatter tests ([72f09be](https://github.com/qlover/fe-base/commit/72f09be48ae1a6e5c799ae33761a54d0ae5fb7e4)) ([#639](https://github.com/qlover/fe-base/pull/639))
+
 ## 5.0.0
 
 ### Major Changes

--- a/packages/fe-release/package.json
+++ b/packages/fe-release/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/fe-release",
   "description": "A tool for releasing front-end projects, supporting multiple release modes and configurations, simplifying the release process and improving efficiency.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/fe-release",

--- a/packages/scripts-context/package.json
+++ b/packages/scripts-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/scripts-context",
   "description": "A scripts context for frontwork",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/fe-base/tree/master/packages/scripts-context#readme",


### PR DESCRIPTION
## Changelog

#### ✨ Features

- **fe-release:** enhance GitHub Actions release workflow and improve package detection ([c245fea](https://github.com/qlover/fe-base/commit/c245fea933169a0a0d363931c84b2665397e659c)) ([#644](https://github.com/qlover/fe-base/pull/644))
#### 🐞 Bug Fixes

- **fe-release:** exclude restored dependency packages from release PR ([ed431ab](https://github.com/qlover/fe-base/commit/ed431abdfaa449eb987a696a01fd7d8713cc43b4)) ([#644](https://github.com/qlover/fe-base/pull/644))

- **fe-release:** honor increment:* labels on release PRs ([7e03012](https://github.com/qlover/fe-base/commit/7e0301208317380d0aff9b56870311ce0bf71835)) ([#642](https://github.com/qlover/fe-base/pull/642))

- **fe-release:** detect changed packages after merge to master ([e25b6ad](https://github.com/qlover/fe-base/commit/e25b6adeee3cebed8610f8393952aca942d94c32)) ([#640](https://github.com/qlover/fe-base/pull/640))
#### ♻️ Refactors

- **fe-release:** consolidate release pipeline and fix dependency-release changelog handling ([3e19ab6](https://github.com/qlover/fe-base/commit/3e19ab6f5e5af61609aa998757b54ce2701e8579)) ([#639](https://github.com/qlover/fe-base/pull/639))

- **fe-release:** improve test readability in ReleaseFormatter tests ([72f09be](https://github.com/qlover/fe-base/commit/72f09be48ae1a6e5c799ae33761a54d0ae5fb7e4)) ([#639](https://github.com/qlover/fe-base/pull/639))