### PR TITLE
feat(fe-release): friendlier release PR titles/bodies and preRelease …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # PR merged to master with CI-Release (non-release head) -> version bump + create release PR
+  # PR merged to master with preRelease (non-release head) -> version bump + create release PR
   create-release-pr:
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -23,7 +23,7 @@ jobs:
         github.event.pull_request.merged == true &&
         github.event.pull_request.base.ref == 'master' &&
         !startsWith(github.event.pull_request.head.ref, 'release/') &&
-        contains(github.event.pull_request.labels.*.name, 'CI-Release')
+        contains(github.event.pull_request.labels.*.name, 'preRelease')
       )
     runs-on: ubuntu-latest
     env:

--- a/packages/fe-release/__tests__/implements/ReleaseFormatter.test.ts
+++ b/packages/fe-release/__tests__/implements/ReleaseFormatter.test.ts
@@ -31,7 +31,57 @@ describe('ReleaseFormatter', () => {
     }
   ];
 
-  it('should format PR title with release metadata', () => {
+  it('should use friendly default PR title for 1–2 packages', () => {
+    const formatter = new ReleaseFormatter(engine, {
+      repoName: 'fe-base',
+      releaseId: 'a1b2c3d4'
+    });
+
+    const title = formatter.getPRTitle(
+      releaseBranchResult,
+      context,
+      workspaces
+    );
+
+    expect(title).toBe('Release pkg-a@1.0.1');
+  });
+
+  it('should include package count in PR title when more than 2 packages', () => {
+    const formatter = new ReleaseFormatter(engine, {
+      repoName: 'fe-base',
+      releaseId: 'a1b2c3d4'
+    });
+
+    const many: WorkspaceInterface[] = [
+      workspaces[0],
+      {
+        name: 'pkg-b',
+        version: '2.0.0',
+        newVersion: '2.1.0',
+        path: 'packages/b',
+        root: '/repo/packages/b',
+        packageJson: { name: 'pkg-b', version: '2.0.0' },
+        changelog: '- fix: bug'
+      },
+      {
+        name: 'pkg-c',
+        version: '3.0.0',
+        newVersion: '3.0.1',
+        path: 'packages/c',
+        root: '/repo/packages/c',
+        packageJson: { name: 'pkg-c', version: '3.0.0' },
+        changelog: '- docs: update'
+      }
+    ];
+
+    const title = formatter.getPRTitle(releaseBranchResult, context, many);
+
+    expect(title).toBe(
+      'Release 3 packages: pkg-a@1.0.1,pkg-b@2.1.0,pkg-c@3.0.1'
+    );
+  });
+
+  it('should format PR title with custom template', () => {
     const formatter = new ReleaseFormatter(engine, {
       repoName: 'fe-base',
       releaseId: 'a1b2c3d4',
@@ -49,28 +99,33 @@ describe('ReleaseFormatter', () => {
     );
   });
 
-  it('should format PR body with single workspace changelog', () => {
+  it('should format single workspace PR body like multi (name@version + change type)', () => {
     const formatter = new ReleaseFormatter(engine, {
-      PRBody: 'Tag: ${tagName}\n\n${changelog}'
+      increment: 'patch'
     });
 
     const body = formatter.getPRBody(workspaces, releaseBranchResult, context);
 
-    expect(body).toBe(
-      'Tag: release-tag-1-patch-a1b2c3d4\n\n- feat: add feature'
-    );
+    expect(body).toContain('## Changelog');
+    expect(body).toContain('### pkg-a@1.0.1');
+    expect(body).toContain('#### Patch Changes');
+    expect(body).toContain('- feat: add feature');
   });
 
-  it('should use default PR body template', () => {
-    const formatter = new ReleaseFormatter(engine, {});
+  it('should use Minor Changes when increment is minor', () => {
+    const formatter = new ReleaseFormatter(engine, {
+      increment: 'minor'
+    });
+
     const body = formatter.getPRBody(workspaces, releaseBranchResult, context);
 
-    expect(body).toBe('## Changelog\n\n- feat: add feature');
+    expect(body).toContain('#### Minor Changes');
   });
 
   it('should format PR body with batch changelogs', () => {
     const formatter = new ReleaseFormatter(engine, {
-      PRBody: '${tagName}\n${changelog}'
+      PRBody: '${tagName}\n${changelog}',
+      increment: 'patch'
     });
 
     const body = formatter.getPRBody(
@@ -91,9 +146,10 @@ describe('ReleaseFormatter', () => {
     );
 
     expect(body).toContain('pkg-a@1.0.1 pkg-b@2.1.0');
-    expect(body).toContain('## pkg-a 1.0.1');
+    expect(body).toContain('### pkg-a@1.0.1');
+    expect(body).toContain('#### Patch Changes');
     expect(body).toContain('- feat: add feature');
-    expect(body).toContain('## pkg-b 2.1.0');
+    expect(body).toContain('### pkg-b@2.1.0');
     expect(body).toContain('- fix: bug');
   });
 

--- a/packages/fe-release/src/defaults.ts
+++ b/packages/fe-release/src/defaults.ts
@@ -30,16 +30,24 @@ export const releaseJson = {
     autoMergeReleasePR: false,
     pushChangeLabels: false,
     skipCreateReleasePR: false,
-    PRTitle: 'Release ${env} ${pkgName} ${tagName}',
+    /** Used when releasing 1–2 packages */
+    PRTitle: 'Release ${spaces}',
+    /** Used when releasing more than 2 packages */
+    PRTitleMany: 'Release ${count} packages: ${spaces}',
     PRBody: '## Changelog\n\n${changelog}',
-    batchPRBody: '\n## ${name} ${newVersion}\n${changelog}\n',
+    /**
+     * Per-workspace section in the PR body (single and multi package).
+     * `${changeTypeSection}` is Patch/Minor/Major Changes from increment.
+     */
+    batchPRBody:
+      '\n### ${name}@${newVersion}\n\n#### ${changeTypeSection}\n\n${changelog}\n',
     branchName: 'release/${repoName}-${releaseId}',
     releaseTagName: 'release-tag-${count}-patch-${releaseId}',
     commitMessage: 'chore(release): ${spaces}',
     label: {
       name: 'CI-Release',
       color: '1A7F37',
-      description: 'Release PR'
+      description: 'Automated release PR (merge to publish)'
     }
   },
   changesetVersion: {

--- a/packages/fe-release/src/implments/ReleaseFormatter.ts
+++ b/packages/fe-release/src/implments/ReleaseFormatter.ts
@@ -170,11 +170,20 @@ export interface ReleaseFormatterConfig {
       };
 
   /**
-   * Pull request title template
+   * Pull request title template (1–2 packages)
    *
-   * @default {@link DEFAULT_PR_TITLE}
+   * @default {@link releaseJson.github.PRTitle}
    */
   PRTitle?: string;
+
+  /**
+   * Pull request title template when releasing more than 2 packages
+   *
+   * Falls back to {@link PRTitle} when unset.
+   *
+   * @default {@link releaseJson.github.PRTitleMany}
+   */
+  PRTitleMany?: string;
 
   /**
    * Pull request body template
@@ -184,11 +193,20 @@ export interface ReleaseFormatterConfig {
   PRBody?: string;
 
   /**
-   * Template for each workspace section in a multi-workspace PR body
+   * Template for each workspace section in the PR body
+   *
+   * Used for both single- and multi-workspace releases.
+   * Supports `${changeTypeSection}` (Patch/Minor/Major Changes).
    *
    * @default from release.json
    */
   batchPRBody?: string;
+
+  /**
+   * Semver increment used to title changelog sections (patch | minor | major)
+   * @default 'patch'
+   */
+  increment?: string;
 }
 
 /**
@@ -315,30 +333,42 @@ export class ReleaseFormatter {
       return '';
     }
 
-    if (workspaces.length === 1) {
-      return workspaces[0].changelog || '';
-    }
+    const changeTypeSection = this.getChangeTypeSection();
+    const batchTpl = this.config.batchPRBody || releaseJson.github.batchPRBody;
 
     return workspaces
       .map((workspace) =>
-        this.templateEngine.render(
-          this.config.batchPRBody || releaseJson.github.batchPRBody,
-          {
-            ...workspace,
-            // Prefer bumped version in PR changelog section headers
-            version: workspace.newVersion || workspace.version,
-            newVersion: workspace.newVersion || workspace.version
-          }
-        )
+        this.templateEngine.render(batchTpl, {
+          ...workspace,
+          // Prefer bumped version in PR changelog section headers
+          version: workspace.newVersion || workspace.version,
+          newVersion: workspace.newVersion || workspace.version,
+          changeTypeSection
+        })
       )
       .join('\n');
+  }
+
+  /**
+   * Map semver increment to Changesets-style section title.
+   */
+  protected getChangeTypeSection(): string {
+    const increment = (this.config.increment || 'patch').toLowerCase();
+
+    if (increment === 'major') {
+      return 'Major Changes';
+    }
+    if (increment === 'minor') {
+      return 'Minor Changes';
+    }
+    return 'Patch Changes';
   }
 
   protected formatPRTagName(
     workspaces: WorkspaceInterface[],
     releaseBranchResult: ReleaseBranchResult
   ): string {
-    if (workspaces.length <= 1) {
+    if (workspaces.length === 0) {
       return releaseBranchResult.releaseTagName;
     }
 
@@ -355,7 +385,14 @@ export class ReleaseFormatter {
     context: TemplateContext,
     workspaces: WorkspaceInterface[] = []
   ): string {
-    const prTitleTpl = this.config.PRTitle || releaseJson.github.PRTitle;
+    const count = workspaces.length;
+    // More than 2 packages: prefer PRTitleMany (includes ${count})
+    const prTitleTpl =
+      count > 2
+        ? this.config.PRTitleMany ||
+          this.config.PRTitle ||
+          releaseJson.github.PRTitleMany
+        : this.config.PRTitle || releaseJson.github.PRTitle;
 
     return this.templateEngine.render(
       prTitleTpl,

--- a/packages/fe-release/src/index.ts
+++ b/packages/fe-release/src/index.ts
@@ -18,12 +18,12 @@
  *
  * ## fe-base workflow (master-only)
  *
- * Feature work merges into `master`. When a merge carries the `CI-Release` label,
+ * Feature work merges into `master`. When a merge carries the `preRelease` label,
  * CI creates a release PR; merging that release PR publishes.
  *
  * ```
  * feature/*  ──PR──►  master  ──fe-release──►  release/*  ──PR──►  master  ──►  npm
- *                  (+ CI-Release)
+ *                  (+ preRelease)              (+ CI-Release)
  * ```
  *
  * ### Phase 1 — Feature PR (base: `master`)
@@ -31,16 +31,16 @@
  * - **CI** (`.github/workflows/general-check.yml`): lint, test, build on every PR.
  * - Changed packages are detected later by `fe-release` via **git diff** (no `changes:*` labels).
  *
- * ### Phase 2 — Create release PR (trigger: `CI-Release` on merged master PR)
+ * ### Phase 2 — Create release PR (trigger: `preRelease` on merged master PR)
  *
  * - **CI** (`.github/workflows/release.yml` → `create-release-pr`):
- *   - Runs when a **merged** PR into `master` has the **`CI-Release`** label at merge time,
+ *   - Runs when a **merged** PR into `master` has the **`preRelease`** label at merge time,
  *     and the PR head is **not** a `release/*` branch, or via `workflow_dispatch`.
  *   - Checks out `master`, runs `fe-release` in default **`changesetVersion` version** mode (`-s master`).
  *   - Detects changed packages with git diff, bumps versions, updates `CHANGELOG.md`,
  *     pushes `release/<repo>-<id>`, opens PR to `master`.
  *   - The new release PR is labeled **`CI-Release`** (see `release.github.label.name`).
- *   - Merges into `master` **without** `CI-Release` do **not** create a release PR (manual gate).
+ *   - Merges into `master` **without** `preRelease` do **not** create a release PR (manual gate).
  *
  * ```bash
  * # Equivalent local / CI command (create release PR)
@@ -48,7 +48,7 @@
  *   --changesetVersion.ignore-non-updated-packages
  * ```
  *
- * Open feature PRs with **`CI-Release`** skip `general-check`.
+ * Open **`release/*`** PRs with **`CI-Release`** skip `general-check`.
  *
  * ### Phase 3 — Publish (trigger: release PR merged into `master`)
  *
@@ -68,10 +68,11 @@
  *
  * | Label | Added by | Purpose |
  * |-------|----------|---------|
- * | `CI-Release` | Manual on feature PR (gate); auto on release PR | Triggers version + release PR; skips general-check; publish when `release/*` merges to master |
+ * | `preRelease` | Manual on feature PR | Gate: merge triggers create-release-pr job |
+ * | `CI-Release` | Auto on `release/*` PR | Identifies automated release PR; merge triggers publish; skips general-check |
  * | `increment:major` / `increment:minor` / `increment:patch` | Manual on PR | Override semver bump (default: patch) |
  *
- * Use a single **`CI-Release`** label for release PRs — do not add a separate `Release` label.
+ * Do **not** put `CI-Release` on feature PRs — use **`preRelease`** to request a release.
  *
  * ### fe-config.json (minimal example)
  *

--- a/packages/fe-release/src/plugins/Github.ts
+++ b/packages/fe-release/src/plugins/Github.ts
@@ -273,7 +273,10 @@ export default class Github extends GitBase<GithubProps> {
       repoName: this.context.options.repoName,
       authorName: this.context.options.authorName,
       env: this.context.options.releaseEnv,
-      releaseId: this.context.releaseId
+      releaseId: this.context.releaseId,
+      increment:
+        this.context.parameters.changesetVersion?.increment ||
+        releaseJson.changesetVersion.increment
     });
 
     this.logger.info(`Github mode: ${this.mode}`);


### PR DESCRIPTION
…trigger

Use preRelease on feature PRs to create release PRs; keep CI-Release for publish. Default titles use package@version (with count when >2 packages) and unify PR body sections.