### PR TITLE
chore(release): Bump versions for multiple packages to 1.2.1, 0.2.1, …

### DIFF
--- a/examples/browser-plugin-seed/package.json
+++ b/examples/browser-plugin-seed/package.json
@@ -2,7 +2,7 @@
   "name": "examples/browser-plugin-seed",
   "private": true,
   "displayName": "Browser Plugin Seed",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Plasmo + React browser extension seed with corekit",
   "author": "qlover",
   "scripts": {

--- a/examples/next-oauth/package.json
+++ b/examples/next-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-oauth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Next.js OAuth 2.0 authorization server example",
   "scripts": {

--- a/examples/next-seed/package.json
+++ b/examples/next-seed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-seed",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "Next.js app shell with theme, i18n, and auth",
   "scripts": {

--- a/examples/react-seed/package.json
+++ b/examples/react-seed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples/react-seed",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Vite + React 19 SPA seed with corekit, i18n, and Tailwind",
   "type": "module",
   "scripts": {

--- a/examples/taro-seed/package.json
+++ b/examples/taro-seed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/taro-seed",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": true,
   "description": "Taro + React + Vite multi-end mini program / H5 seed",
   "templateInfo": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlover/create-app",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Create a new app with a single command",
   "private": false,
   "type": "module",

--- a/packages/fe-corekit/package.json
+++ b/packages/fe-corekit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/fe-corekit",
   "description": "A corekit for frontwork",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": false,
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
…1.3.1, 1.4.1, 2.2.1, 3.3.1, and 3.4.1

- Updated package versions in examples/browser-plugin-seed, examples/next-oauth, examples/next-seed, examples/react-seed, examples/taro-seed, packages/create-app, and packages/fe-corekit to reflect minor improvements and updates.