### PR TITLE
fix(next-oauth): skip locale rewrite for OAuth endpoints and store re…

### DIFF
--- a/.github/workflows/general-check.yml
+++ b/.github/workflows/general-check.yml
@@ -50,9 +50,14 @@ jobs:
             nx-cache-${{ github.ref_name }}-
             nx-cache-master-
       
+      # 使用 build:packages:force，而不是 build:packages（nx affected）。
+      # examples 通过 package.json 解析 @qlover/* 类型到 dist/*.d.ts，且 dist 被 gitignore。
+      # 当 PR 只改 examples 时，nx affected:build --exclude=examples 往往不会构建任何 package，
+      # type-check 会因缺少 dist 报 TS2307。强制构建全部 packages，保证 example type-check 前
+      # dist 一定存在（与 release.yml 一致）。
       - name: Build packages (exclude examples)
         timeout-minutes: 10
-        run: pnpm build:packages
+        run: pnpm build:packages:force
 
       - name: Type check
         timeout-minutes: 10

--- a/examples/next-oauth/server/providers/SupabaseOAuthProvider.ts
+++ b/examples/next-oauth/server/providers/SupabaseOAuthProvider.ts
@@ -348,8 +348,10 @@ export class SupabaseOAuthProvider
     });
 
     const oauthRepo = this.getOAuthRepo();
+    // oauth-wrapper reads provider_session_token as the upstream refresh token
+    // when exchanging authorization codes (fetchProviderAccessToken).
     await oauthRepo.upsertUserCredentials(profile.id, {
-      provider_session_token: profile.credential_token
+      provider_session_token: refreshToken
     });
   }
 

--- a/examples/next-oauth/shared/config/route.ts
+++ b/examples/next-oauth/shared/config/route.ts
@@ -71,6 +71,16 @@ export const OAUTH_MACHINE_ROUTES = [
   ROUTE_CALLBACK_EMAIL_LOGIN
 ] as const;
 
+/**
+ * OAuth endpoints mounted at `src/app/oauth/*` (no `[locale]` segment).
+ * next-intl must not rewrite these to `/zh/oauth/token` etc.
+ */
+export const OAUTH_LOCALE_AGNOSTIC_ROUTES = [
+  ROUTE_OAUTH_TOKEN,
+  ROUTE_OAUTH_REVOKE,
+  ROUTE_OAUTH_USERINFO
+] as const;
+
 /** Routes that are allowed without authentication (public routes). */
 export const AUTH_ROUTES = [
   ROUTE_HOME,
@@ -94,6 +104,16 @@ export const LOGINED_PAGES = [
  */
 export function isOAuthMachinePath(pathname: string): boolean {
   return OAUTH_MACHINE_ROUTES.some(
+    (route) => pathname === route || pathname.endsWith(route)
+  );
+}
+
+/**
+ * Returns true if pathname is a locale-agnostic OAuth endpoint
+ * (`/oauth/token`, `/oauth/revoke`, `/oauth/userinfo`).
+ */
+export function isOAuthLocaleAgnosticPath(pathname: string): boolean {
+  return OAUTH_LOCALE_AGNOSTIC_ROUTES.some(
     (route) => pathname === route || pathname.endsWith(route)
   );
 }

--- a/examples/next-oauth/src/proxy.ts
+++ b/examples/next-oauth/src/proxy.ts
@@ -1,6 +1,10 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import createMiddleware from 'next-intl/middleware';
-import { isAuthGuestOnlyPath, ROUTE_HOME } from '@config/route';
+import {
+  isAuthGuestOnlyPath,
+  isOAuthLocaleAgnosticPath,
+  ROUTE_HOME
+} from '@config/route';
 import { ServerConfig } from '@server/ServerConfig';
 import { OAuthSessionService } from '@server/services/OAuthSessionService';
 import { routing } from './i18n/routing';
@@ -12,6 +16,14 @@ import { routing } from './i18n/routing';
  * 3. 已登录访问 guest-only auth 页时，重定向到首页
  */
 export default async function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  // `/oauth/token|revoke|userinfo` live under `src/app/oauth/*` (no locale).
+  // Skip next-intl so POST /oauth/token is not redirected to /zh/oauth/token.
+  if (isOAuthLocaleAgnosticPath(pathname)) {
+    return NextResponse.next();
+  }
+
   // ---------- 第一步：处理国际化 ----------
   const localPathResponse = createMiddleware(routing)(request);
 
@@ -29,7 +41,6 @@ export default async function proxy(request: NextRequest) {
   }
 
   // ---------- 第三步：已登录用户不应再访问 login / register ----------
-  const pathname = request.nextUrl.pathname;
   if (
     isAuthGuestOnlyPath(pathname) &&
     oauthSession.hasSessionFromRequest(request)
@@ -50,6 +61,7 @@ export default async function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     '/',
-    '/((?!api|_next|.*\\.(?:svg|png|jpg|jpeg|gif|ico)|favicon.ico|sitemap.xml|sitemap-0.xml|manifest.webmanifest).*)'
+    // Exclude App Router OAuth machine endpoints (no locale prefix).
+    '/((?!api|oauth/token|oauth/revoke|oauth/userinfo|_next|.*\\.(?:svg|png|jpg|jpeg|gif|ico)|favicon.ico|sitemap.xml|sitemap-0.xml|manifest.webmanifest).*)'
   ]
 };


### PR DESCRIPTION
…fresh token

Prevent next-intl from redirecting /oauth/token|revoke|userinfo, and persist the upstream refresh token as provider_session_token.