### PR TITLE
fix(next-oauth): OAuth 机器端点返回扁平 RFC JSON 并完善 SSO 回调

### DIFF
--- a/examples/next-oauth/README.en.md
+++ b/examples/next-oauth/README.en.md
@@ -129,7 +129,7 @@ cp .env.template .env
 
 | Endpoint | Method | Notes |
 | -------- | ------ | ----- |
-| `/[locale]/oauth/authorize` | GET | Consent UI (requires session) |
+| `/[locale]/oauth/authorize` | GET | Consent UI (`LOGINED_PAGES`; unauthenticated → `/auth/login?redirect=<full authorize URL>`, then resume consent) |
 | `/api/oauth/verify` | POST | Email/password login → session + stored upstream tokens |
 | `/api/oauth/consent` | POST | Approve/deny → `redirectUrl` with `code` or OAuth error |
 | `/oauth/token` | POST | Token endpoint (form body, optional HTTP Basic) |

--- a/examples/next-oauth/README.md
+++ b/examples/next-oauth/README.md
@@ -239,7 +239,7 @@ npm run dev:prod     # 生产配置态本地调试
 
 | 端点 | 方法 | 说明 |
 | ---- | ---- | ---- |
-| `/[locale]/oauth/authorize` | GET | 授权同意页（需已登录会话） |
+| `/[locale]/oauth/authorize` | GET | 授权同意页（`LOGINED_PAGES`；未登录经中间件跳 `/auth/login?redirect=<完整 authorize URL>`，登录后回跳继续同意） |
 | `/api/oauth/verify` | POST | 邮箱密码登录，写入会话 + 上游凭证（JSON body：`email`, `password`） |
 | `/api/oauth/consent` | POST | 用户同意/拒绝，返回 `redirectUrl`（含 `code` 或 `error`） |
 | `/api/oauth/playground/validate` | POST | Playground：校验授权查询参数 |

--- a/examples/next-oauth/README.md
+++ b/examples/next-oauth/README.md
@@ -230,7 +230,10 @@ npm run dev:prod     # 生产配置态本地调试
 机器端点 **不带 locale 前缀**，且由 `src/proxy.ts` 跳过会话中间件：
 
 - `POST /oauth/token`
-- `GET /userinfo`
+- `GET /oauth/userinfo`
+- `POST /oauth/revoke`
+
+上述端点返回 **扁平 RFC JSON**（`runWithOAuthJson`），可被 Supabase Custom Auth Provider 等标准客户端消费。详见 [docs/oauth-as-supabase-custom-provider.md](./docs/oauth-as-supabase-custom-provider.md)。
 
 ### HTTP 端点一览
 

--- a/examples/next-oauth/docs/oauth-as-supabase-custom-provider.md
+++ b/examples/next-oauth/docs/oauth-as-supabase-custom-provider.md
@@ -43,6 +43,12 @@ Playground 使用 `readOAuthMachineJson` 解析上述端点。
 
 Authorization URL 建议带 locale：`/{locale}/oauth/authorize`；Token / Userinfo **无** locale。
 
+未登录用户打开 authorize 时，`src/proxy.ts` 会因 `LOGINED_PAGES` 含 `ROUTE_OAUTH_AUTHORIZE`，经 `redirectToPath` 跳到：
+
+`/{locale}/auth/login?redirect=/{locale}/oauth/authorize?client_id=...&...`
+
+密码登录后 `useReturnTo` 读 `redirect`，回到完整授权 URL 再同意。勿在未登录时直接渲染同意页（否则 consent 会报 `User session expired`）。
+
 ## 3. 消费方 SSO 回调错误处理
 
 `/api/callback/provider-login` 在只有 `error` / `error_description`（无 `code`）时应重定向到登录页并展示错误，避免 Zod 强制 `code: string` 误报。

--- a/examples/next-oauth/docs/oauth-as-supabase-custom-provider.md
+++ b/examples/next-oauth/docs/oauth-as-supabase-custom-provider.md
@@ -1,0 +1,59 @@
+# next-oauth：作为 IdP 对接 Supabase Custom Auth Provider
+
+本文记录模板作为 **OAuth 授权服务器**（Developer Apps / oauth-wrapper）时，被其它项目的 Supabase Custom Provider 消费所需的约定。  
+PDC ↔ PAM 完整联调踩坑见 PDC 仓库 `apps/web/docs/pam-oauth-login-troubleshooting.md`。
+
+## 1. Token / Userinfo 必须返回扁平 RFC JSON
+
+标准 OAuth 客户端（含 Supabase Auth）期望：
+
+```json
+{ "access_token": "...", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "..." }
+```
+
+失败时：
+
+```json
+{ "error": "invalid_grant", "error_description": "..." }
+```
+
+**不要**再包一层 App API 信封 `{ "success": true, "data": { ... } }`，否则会出现：
+
+`Unable to exchange external code: xxxx`
+
+本模板通过 `NextApiServer.runWithOAuthJson` 输出扁平响应，用于：
+
+- `POST /oauth/token`
+- `GET /oauth/userinfo`（claims：`sub` / `email` / `email_verified` / `name`）
+- `POST /oauth/revoke`
+
+Playground 使用 `readOAuthMachineJson` 解析上述端点。
+
+## 2. 两套「OAuth 应用」不要混用
+
+| 位置 | 角色 |
+| --- | --- |
+| 本站 **Developer → Apps** | 本站 oauth-wrapper 的 Client 登记（`/oauth/authorize`） |
+| 本站 **上游 Supabase → OAuth Apps** | Supabase 原生 OAuth Server（另一套端点） |
+| 消费方 **Supabase → Custom Auth Provider** | 消费方把本站当 IdP（`custom:my-idp`） |
+
+消费方 Custom Provider 的 Client ID/Secret 必须来自本站 **Developer Apps**，`redirect_uri` 必须是消费方 Supabase 的：
+
+`https://<consumer-ref>.supabase.co/auth/v1/callback`
+
+Authorization URL 建议带 locale：`/{locale}/oauth/authorize`；Token / Userinfo **无** locale。
+
+## 3. 消费方 SSO 回调错误处理
+
+`/api/callback/provider-login` 在只有 `error` / `error_description`（无 `code`）时应重定向到登录页并展示错误，避免 Zod 强制 `code: string` 误报。
+
+`SITE_URL` 末尾若带 `/`，拼接 `/api/...` 时会得到 `//api`；`loginWithProvider` 应 strip 后再拼。
+
+## 4. Preview 部署注意
+
+若消费方 Supabase 要调 Preview 的 `/oauth/token`，须关闭 Vercel **Deployment Protection → Require Log In**。  
+浏览器能登录 ≠ 机房能 POST；Protection Bypass header Supabase 换票时加不了。
+
+## 5. 扩展 Custom SSO 按钮（可选）
+
+在 `loginProviders` 增加展示名后，于 `resolveSupabaseOAuthProvider` 映射到 `custom:your-id`（见 `shared/config/common.ts`），再在消费方/本站上游 Supabase Dashboard 配置对应 Custom Provider。

--- a/examples/next-oauth/server/NextApiServer.ts
+++ b/examples/next-oauth/server/NextApiServer.ts
@@ -1,6 +1,7 @@
 import { isPlainObject, pick } from 'lodash-es';
 import { NextResponse, type NextRequest } from 'next/server';
 import { I } from '@config/ioc-identifiter';
+import { oauthI18nIdToRfc } from '@config/oauthErrors';
 import type {
   AppApiResult,
   AppApiSuccessInterface
@@ -132,6 +133,53 @@ export class NextApiServer extends BootstrapServer {
   ): Promise<NextResponse> {
     const result = await this.run(task);
     return this.returnJson(result, init);
+  }
+
+  /**
+   * Machine OAuth endpoints (token / userinfo / revoke) for RFC clients
+   * such as Supabase Custom OAuth providers.
+   *
+   * Success: return the payload itself (no `{ success, data }` envelope).
+   * Error: `{ error, error_description }` per RFC 6749 §5.2.
+   */
+  public async runWithOAuthJson<Result>(
+    task?: RunWithTask<Result>,
+    init?: RunWithInit
+  ): Promise<NextResponse> {
+    const result = await this.run(task);
+    const contextHttpStatus = this.serverContext.getState('httpStatus');
+    const noStoreHeaders = {
+      'Cache-Control': 'no-store',
+      Pragma: 'no-cache'
+    };
+
+    if (!result.success) {
+      return NextResponse.json(
+        {
+          error: oauthI18nIdToRfc(result.id ?? 'server_error'),
+          error_description:
+            result.message?.trim() || result.id || 'OAuth error'
+        },
+        {
+          status: contextHttpStatus ?? 400,
+          headers: {
+            ...noStoreHeaders,
+            ...init?.errorHeaders
+          }
+        }
+      );
+    }
+
+    const body =
+      result.data === undefined || result.data === null ? {} : result.data;
+
+    return NextResponse.json(body as object, {
+      status: contextHttpStatus ?? 200,
+      headers: {
+        ...noStoreHeaders,
+        ...init?.successHeaders
+      }
+    });
   }
 
   /**

--- a/examples/next-oauth/server/services/OAuthUserService.ts
+++ b/examples/next-oauth/server/services/OAuthUserService.ts
@@ -4,17 +4,20 @@ import {
   SignWithOtpSchema,
   VerifyOtpParams
 } from '@qlover/oauth-wrapper';
-import { Provider } from '@supabase/supabase-js';
 import { isEmpty } from 'lodash-es';
 import { cookies } from 'next/headers';
 import { inject, injectable } from '@shared/container';
 import { API_CALLBACK_PROVIDER_LOGIN } from '@config/apiRoutes';
-import { LoginProviderType } from '@config/common';
+import {
+  LoginProviderType,
+  resolveSupabaseOAuthProvider
+} from '@config/common';
 import {
   API_NOT_AUTHORIZED,
   API_USER_NOT_FOUND
 } from '@config/i18n-identifier/api';
 import { I } from '@config/ioc-identifiter';
+import { ROUTE_LOGIN } from '@config/route';
 import { LoginWithProviderCallbackSchema } from '@schemas/LoginSchema';
 import type { UserSchema } from '@schemas/UserSchema';
 import type { SeedServerConfigInterface } from '@interfaces/SeedConfigInterface';
@@ -33,6 +36,7 @@ import type {
 } from '../interfaces/UserServiceInterface';
 import type { EncryptorInterface } from '@qlover/fe-corekit/encrypt';
 import type { LoggerInterface } from '@qlover/logger';
+import type { Provider } from '@supabase/supabase-js';
 
 @injectable()
 export class OAuthUserService
@@ -208,18 +212,18 @@ export class OAuthUserService
   }): Promise<LoginProviderResult> {
     const supabase = await this.supabaseRepo.getSupabase();
 
-    // FIXME: toLocaleLowerCase 不够严谨
-    const supabsaeProvider = provider.toLocaleLowerCase() as Provider;
-    const redirectTo = this.config.siteUrl + API_CALLBACK_PROVIDER_LOGIN;
+    const supabaseProvider = resolveSupabaseOAuthProvider(provider);
+    const siteBase = this.config.siteUrl.replace(/\/$/, '');
+    const redirectTo = `${siteBase}${API_CALLBACK_PROVIDER_LOGIN}`;
 
     this.logger.debug(
       'loginwithProvider:',
-      supabsaeProvider,
+      supabaseProvider,
       'redirectTo:',
       redirectTo
     );
     const result = await supabase.auth.signInWithOAuth({
-      provider: supabsaeProvider,
+      provider: supabaseProvider as Provider,
       options: {
         redirectTo
       }
@@ -239,6 +243,34 @@ export class OAuthUserService
   public async loginWithProviderCallback(
     query: LoginWithProviderCallbackSchema
   ): Promise<ResultHandlerContext> {
+    const siteUrl = query.origin ?? this.config.siteUrl;
+    const siteBase = siteUrl.replace(/\/$/, '');
+
+    if (query.error) {
+      const description =
+        query.error_description?.trim() ||
+        query.error_code?.trim() ||
+        query.error;
+      this.logger.error('OAuth provider callback error', {
+        error: query.error,
+        error_code: query.error_code,
+        error_description: query.error_description
+      });
+
+      const loginUrl = new URL(ROUTE_LOGIN, `${siteBase}/`);
+      loginUrl.searchParams.set('oauth_error', description);
+      return {
+        redirectUrl: loginUrl.toString()
+      };
+    }
+
+    if (!query.code?.trim()) {
+      throw new ExecutorError(
+        API_NOT_AUTHORIZED,
+        'OAuth callback missing authorization code'
+      );
+    }
+
     const supabase = await this.supabaseRepo.getSupabase();
 
     const result = await supabase.auth.exchangeCodeForSession(query.code);
@@ -248,12 +280,8 @@ export class OAuthUserService
     await this.oauthProvider.loginWithSession?.(result.data.session!);
 
     const nextPathname = query.next ?? '/';
-    const siteUrl = query.origin ?? this.config.siteUrl;
     return {
-      redirectUrl: new URL(
-        nextPathname,
-        siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`
-      ).toString()
+      redirectUrl: new URL(nextPathname, `${siteBase}/`).toString()
     };
   }
 }

--- a/examples/next-oauth/shared/config/common.ts
+++ b/examples/next-oauth/shared/config/common.ts
@@ -103,6 +103,18 @@ export const loginProviders = {
 export type LoginProviderType = ValueOf<typeof loginProviders>;
 
 /**
+ * Maps UI `loginProviders` names to Supabase Auth `signInWithOAuth` provider ids.
+ *
+ * Built-ins: `GitHub` → `github`. For Supabase Custom Auth Providers, extend this
+ * map to return ids like `custom:my-idp` (do not rely on naive toLowerCase).
+ */
+export function resolveSupabaseOAuthProvider(
+  provider: LoginProviderType
+): string {
+  return provider.toLowerCase();
+}
+
+/**
  * Upstream identity provider for the Next OAuth template.
  * Read via AppConfig / ServerConfig from `NEXT_PUBLIC_OAUTH_UPSTREAM_PROVIDER`.
  *

--- a/examples/next-oauth/shared/config/route.ts
+++ b/examples/next-oauth/shared/config/route.ts
@@ -96,7 +96,10 @@ export const AUTH_ROUTES = [
 export const LOGINED_PAGES = [
   ROUTE_REQUEST_LOGS,
   ROUTE_DEVELOPER_APPS,
-  ROUTE_OAUTH_PLAYGROUND
+  ROUTE_OAUTH_PLAYGROUND,
+  // Consent requires an app session; gate here so unauthenticated users
+  // are sent to login with `?redirect=<full authorize URL>` via redirectToPath.
+  ROUTE_OAUTH_AUTHORIZE
 ] as const;
 
 /**

--- a/examples/next-oauth/shared/schemas/LoginSchema.ts
+++ b/examples/next-oauth/shared/schemas/LoginSchema.ts
@@ -27,9 +27,12 @@ export const loginWithProviderSchema = z.object({
 });
 
 export const loginWithProviderCallbackSchema = z.object({
-  code: z.string(),
+  code: z.string().optional(),
   next: z.string().optional(),
-  origin: z.string().optional()
+  origin: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+  error_code: z.string().optional()
 });
 
 export type LoginWithProviderCallbackSchema = z.infer<

--- a/examples/next-oauth/src/app/oauth/revoke/route.ts
+++ b/examples/next-oauth/src/app/oauth/revoke/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: NextRequest) {
     name: ROUTE_OAUTH_REVOKE,
     nextRequest: req,
     event_type: 'oauth-wrapper'
-  }).runWithJson(
+  }).runWithOAuthJson(
     async ({ parameters: { IOC } }) =>
       IOC(OAuthWrapperController).revokeToken(
         await parseOAuthTokenRequest(req)

--- a/examples/next-oauth/src/app/oauth/token/route.ts
+++ b/examples/next-oauth/src/app/oauth/token/route.ts
@@ -90,6 +90,9 @@ export async function OPTIONS(req: NextRequest) {
  *
  * Supports `grant_type=authorization_code` and `grant_type=refresh_token`.
  * Client authentication via HTTP Basic or form body parameters.
+ *
+ * Response is a flat token JSON (not the app `{ success, data }` envelope)
+ * so standard OAuth clients (e.g. Supabase Custom Providers) can parse it.
  */
 export async function POST(req: NextRequest) {
   const corsHeaders = buildApiCorsHeaders(req, corsConfig);
@@ -98,7 +101,7 @@ export async function POST(req: NextRequest) {
     name: ROUTE_OAUTH_TOKEN,
     nextRequest: req,
     event_type: 'oauth-wrapper'
-  }).runWithJson(
+  }).runWithOAuthJson(
     async ({ parameters: { IOC } }) =>
       IOC(OAuthWrapperController).exchangeToken(
         await parseOAuthTokenRequest(req)

--- a/examples/next-oauth/src/app/oauth/userinfo/route.ts
+++ b/examples/next-oauth/src/app/oauth/userinfo/route.ts
@@ -35,6 +35,7 @@ export async function OPTIONS(req: NextRequest) {
  * OAuth 2.0 / OIDC userinfo endpoint.
  *
  * Requires `Authorization: Bearer <access_token>` from `POST /oauth/token`.
+ * Returns flat OIDC claims (`sub`, `email`, …) without the app API envelope.
  */
 export async function GET(req: NextRequest) {
   const corsHeaders = buildApiCorsHeaders(req, corsConfig);
@@ -43,7 +44,7 @@ export async function GET(req: NextRequest) {
     name: ROUTE_OAUTH_USERINFO,
     nextRequest: req,
     event_type: 'oauth-wrapper'
-  }).runWithJson(
+  }).runWithOAuthJson(
     async ({ parameters: { IOC } }) => {
       const accessToken = parseBearerAuthorization(
         req.headers.get('authorization')
@@ -57,14 +58,17 @@ export async function GET(req: NextRequest) {
         );
       }
 
-      return await IOC(OAuthWrapperController).getUserInfo(accessToken!);
+      const user = await IOC(OAuthWrapperController).getUserInfo(accessToken!);
+
+      return {
+        sub: String(user.id),
+        email: user.email,
+        email_verified: true,
+        name: user.email
+      };
     },
     {
-      successHeaders: {
-        'Cache-Control': 'no-store',
-        Pragma: 'no-cache',
-        ...corsHeaders
-      },
+      successHeaders: corsHeaders,
       errorHeaders: corsHeaders
     }
   );

--- a/examples/next-oauth/src/proxy.ts
+++ b/examples/next-oauth/src/proxy.ts
@@ -45,6 +45,15 @@ export default async function proxy(request: NextRequest) {
     isAuthGuestOnlyPath(pathname) &&
     oauthSession.hasSessionFromRequest(request)
   ) {
+    // Prefer post-login return URL (e.g. OAuth authorize with full query).
+    const returnTo =
+      request.nextUrl.searchParams.get('redirect') ||
+      request.nextUrl.searchParams.get('return_to') ||
+      request.nextUrl.searchParams.get('returnUrl');
+    if (returnTo?.startsWith('/') && !returnTo.startsWith('//')) {
+      return NextResponse.redirect(new URL(returnTo, request.nextUrl.origin));
+    }
+
     const url = request.nextUrl.clone();
     // Keep locale prefix, e.g. /en/auth/login → /en
     const localeMatch = pathname.match(/^\/([^/]+)\/auth\//);

--- a/examples/next-oauth/src/uikit/components-app/developer/apps/readAppApiJson.ts
+++ b/examples/next-oauth/src/uikit/components-app/developer/apps/readAppApiJson.ts
@@ -17,3 +17,25 @@ export async function readAppApiJson<T>(response: Response): Promise<T> {
 
   return body.data as T;
 }
+
+/**
+ * Parse machine OAuth endpoints (`/oauth/token`, `/oauth/userinfo`, `/oauth/revoke`)
+ * that return flat RFC JSON (no `{ success, data }` envelope).
+ */
+export async function readOAuthMachineJson<T = unknown>(
+  response: Response
+): Promise<T> {
+  const body = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok || typeof body.error === 'string') {
+    const description =
+      typeof body.error_description === 'string'
+        ? body.error_description
+        : typeof body.error === 'string'
+          ? body.error
+          : `OAuth request failed (${response.status})`;
+    throw new Error(description);
+  }
+
+  return body as T;
+}

--- a/examples/next-oauth/src/uikit/components-app/oauth/OAuthPlayground.tsx
+++ b/examples/next-oauth/src/uikit/components-app/oauth/OAuthPlayground.tsx
@@ -24,7 +24,10 @@ import {
 import { Link } from '@/i18n/routing';
 import { AppUserGateway } from '@/impls/AppUserGateway';
 import { Button, buttonClassName } from '@/uikit/components/Button';
-import { readAppApiJson } from '@/uikit/components-app/developer/apps/readAppApiJson';
+import {
+  readAppApiJson,
+  readOAuthMachineJson
+} from '@/uikit/components-app/developer/apps/readAppApiJson';
 import { usePageI18nMapping } from '@/uikit/context/PageI18nContext';
 import { useIOC } from '@/uikit/hook/useIOC';
 import { useUserAuth } from '@/uikit/hook/useUserAuth';
@@ -418,7 +421,7 @@ export function OAuthPlayground() {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: body.toString()
       });
-      const result = await readAppApiJson(res);
+      const result = await readOAuthMachineJson(res);
       setTokenResponse({ status: res.status, body: result });
     } catch (err) {
       setErrorMessage(
@@ -449,7 +452,7 @@ export function OAuthPlayground() {
       const res = await fetch(ROUTE_OAUTH_USERINFO, {
         headers: { Authorization: `Bearer ${accessToken}` }
       });
-      const result = await readAppApiJson(res);
+      const result = await readOAuthMachineJson(res);
       setUserinfoResponse({ status: res.status, body: result });
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : 'Userinfo failed');


### PR DESCRIPTION
token/userinfo/revoke 使用 runWithOAuthJson，避免 App 信封导致 Supabase Custom Provider 换票失败；同步 SITE_URL 拼接与 provider 回调 error 处理。