### PR TITLE
fix(examples): 避免裸 hidden 类被浏览器扩展覆盖显示

### DIFF
--- a/examples/next-oauth/src/app/[locale]/auth/login/page.tsx
+++ b/examples/next-oauth/src/app/[locale]/auth/login/page.tsx
@@ -69,7 +69,7 @@ export default async function LoginPage(props: PageParamsProps) {
         className: 'text-xs1 bg-primary flex min-h-screen'
       }}
     >
-      <div className="hidden lg:flex bg-secondary lg:w-1/2 flex-col p-12">
+      <div className="max-lg:hidden flex bg-secondary lg:w-1/2 flex-col p-12">
         <span className="border-primary-border text-brand mb-4 inline-flex w-fit items-center rounded-full border bg-bg-container px-3 py-1 text-xs font-semibold tracking-wide uppercase">
           OAuth 2.0
         </span>

--- a/examples/next-oauth/src/app/[locale]/auth/register/page.tsx
+++ b/examples/next-oauth/src/app/[locale]/auth/register/page.tsx
@@ -62,7 +62,7 @@ export default async function LoginPage(props: PageParamsProps) {
         className: 'text-xs1 bg-primary flex min-h-screen'
       }}
     >
-      <div className="hidden lg:flex bg-secondary lg:w-1/2 p-12 flex-col">
+      <div className="max-lg:hidden flex bg-secondary lg:w-1/2 p-12 flex-col">
         <h1 className="text-4xl font-bold text-primary-text mb-4">
           {tt.welcome}
         </h1>

--- a/examples/next-oauth/src/uikit/components-app/AppHeaderNavPanel.tsx
+++ b/examples/next-oauth/src/uikit/components-app/AppHeaderNavPanel.tsx
@@ -62,7 +62,7 @@ export function AppHeaderNavPanel({
     <>
       <nav
         data-testid="AppHeaderNav"
-        className="hidden md:flex items-center gap-6 ml-6 lg:ml-8"
+        className="max-md:hidden flex items-center gap-6 ml-6 lg:ml-8"
         aria-label="Main"
       >
         <NavLink

--- a/examples/next-oauth/src/uikit/components-app/LanguageSwitcher.tsx
+++ b/examples/next-oauth/src/uikit/components-app/LanguageSwitcher.tsx
@@ -82,7 +82,7 @@ export function LanguageSwitcher() {
         aria-label={currentLocaleLabel}
       >
         <LanguageIcon className="h-4 w-4 shrink-0" aria-hidden />
-        <span className="hidden sm:inline">{currentLocaleLabel}</span>
+        <span className="max-sm:hidden inline">{currentLocaleLabel}</span>
       </Button>
     </Dropdown>
   );

--- a/examples/next-oauth/src/uikit/components-app/LanguageSwitcherPages.tsx
+++ b/examples/next-oauth/src/uikit/components-app/LanguageSwitcherPages.tsx
@@ -76,7 +76,7 @@ export function LanguageSwitcherPages() {
         aria-label={currentLocaleLabel}
       >
         <LanguageIcon className="h-4 w-4 shrink-0" aria-hidden />
-        <span className="hidden sm:inline">{currentLocaleLabel}</span>
+        <span className="max-sm:hidden inline">{currentLocaleLabel}</span>
       </Button>
     </Dropdown>
   );

--- a/examples/next-oauth/src/uikit/components-app/LogoutButton.tsx
+++ b/examples/next-oauth/src/uikit/components-app/LogoutButton.tsx
@@ -51,7 +51,7 @@ export function LogoutButton(props: { showLabel?: boolean }) {
         <ArrowRightOnRectangleIcon
           className={showLabel ? 'h-4 w-4' : 'h-5 w-5'}
         />
-        {showLabel && <span className="hidden sm:inline">{tt.title}</span>}
+        {showLabel && <span className="max-sm:hidden inline">{tt.title}</span>}
       </Button>
     </Tooltip>
   );

--- a/examples/next-oauth/src/uikit/components-app/RoutePageLayout.tsx
+++ b/examples/next-oauth/src/uikit/components-app/RoutePageLayout.tsx
@@ -91,7 +91,7 @@ export function RoutePageLayout({
                 </LocaleLink>
               )}
               {headerSubtitle && (
-                <span className="hidden sm:inline text-sm text-secondary-text border-l border-primary-border pl-3 shrink-0">
+                <span className="max-sm:hidden inline text-sm text-secondary-text border-l border-primary-border pl-3 shrink-0">
                   {headerSubtitle}
                 </span>
               )}

--- a/examples/next-oauth/src/uikit/components-app/oauth/OAuthAuthorizeCard.tsx
+++ b/examples/next-oauth/src/uikit/components-app/oauth/OAuthAuthorizeCard.tsx
@@ -173,10 +173,8 @@ export function OAuthAuthorizeCard({
             ))}
           </div>
           <div
-            className={clsx(
-              'mt-2 pl-5 text-xs text-secondary-text border-l-2 border-brand/40',
-              !extraOpen && 'hidden'
-            )}
+            hidden={!extraOpen}
+            className="mt-2 pl-5 text-xs text-secondary-text border-l-2 border-brand/40"
           >
             <p>{tt.extraPermNote}</p>
           </div>

--- a/examples/next-oauth/src/uikit/components-pages/AdminLayout.tsx
+++ b/examples/next-oauth/src/uikit/components-pages/AdminLayout.tsx
@@ -189,7 +189,7 @@ export function AdminLayout({
             <Button
               variant="ghost"
               size="sm"
-              className="hidden md:inline-flex"
+              className="max-md:hidden inline-flex"
               aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
               onClick={handleToggleDesktop}
             >
@@ -211,10 +211,10 @@ export function AdminLayout({
                 Admin
               </span>
             </LocaleLink>
-            <span className="bg-primary-border hidden h-4 w-px sm:block" />
+            <span className="bg-primary-border max-sm:hidden h-4 w-px block" />
             <span
               data-testid="admin-header-title"
-              className="text-secondary-text hidden truncate text-sm sm:inline"
+              className="text-secondary-text max-sm:hidden truncate text-sm inline"
             >
               {seoMetadata.title}
             </span>
@@ -232,7 +232,7 @@ export function AdminLayout({
         <aside
           data-testid="AdminLayoutSidebar"
           className={clsx(
-            'border-primary-border bg-secondary hidden h-full shrink-0 flex-col border-r transition-[width] duration-200 ease-out md:flex',
+            'border-primary-border bg-secondary max-md:hidden h-full shrink-0 flex-col border-r transition-[width] duration-200 ease-out flex',
             collapsed ? 'w-16' : 'w-56'
           )}
         >

--- a/examples/next-seed/src/app/[locale]/auth/login/page.tsx
+++ b/examples/next-seed/src/app/[locale]/auth/login/page.tsx
@@ -64,7 +64,7 @@ export default async function LoginPage(props: PageParamsProps) {
         className: 'text-xs1 bg-primary flex min-h-screen'
       }}
     >
-      <div className="hidden lg:flex bg-secondary lg:w-1/2 flex-col p-12">
+      <div className="max-lg:hidden flex bg-secondary lg:w-1/2 flex-col p-12">
         <p className="text-secondary-text mb-6 text-sm font-medium">
           {tt.badge}
         </p>

--- a/examples/next-seed/src/app/[locale]/auth/register/page.tsx
+++ b/examples/next-seed/src/app/[locale]/auth/register/page.tsx
@@ -62,7 +62,7 @@ export default async function LoginPage(props: PageParamsProps) {
         className: 'text-xs1 bg-primary flex min-h-screen'
       }}
     >
-      <div className="hidden lg:flex bg-secondary lg:w-1/2 p-12 flex-col">
+      <div className="max-lg:hidden flex bg-secondary lg:w-1/2 p-12 flex-col">
         <h1 className="text-4xl font-bold text-primary-text mb-4">
           {tt.welcome}
         </h1>

--- a/examples/next-seed/src/uikit/components-app/AppHeaderNavPanel.tsx
+++ b/examples/next-seed/src/uikit/components-app/AppHeaderNavPanel.tsx
@@ -51,7 +51,7 @@ export function AppHeaderNavPanel({
     <>
       <nav
         data-testid="AppHeaderNav"
-        className="hidden md:flex items-center gap-6 ml-6 lg:ml-8"
+        className="max-md:hidden flex items-center gap-6 ml-6 lg:ml-8"
         aria-label="Main"
       >
         <NavLink

--- a/examples/next-seed/src/uikit/components-app/LanguageSwitcher.tsx
+++ b/examples/next-seed/src/uikit/components-app/LanguageSwitcher.tsx
@@ -82,7 +82,7 @@ export function LanguageSwitcher() {
         aria-label={currentLocaleLabel}
       >
         <LanguageIcon className="h-4 w-4 shrink-0" aria-hidden />
-        <span className="hidden sm:inline">{currentLocaleLabel}</span>
+        <span className="max-sm:hidden inline">{currentLocaleLabel}</span>
       </Button>
     </Dropdown>
   );

--- a/examples/next-seed/src/uikit/components-app/LanguageSwitcherPages.tsx
+++ b/examples/next-seed/src/uikit/components-app/LanguageSwitcherPages.tsx
@@ -76,7 +76,7 @@ export function LanguageSwitcherPages() {
         aria-label={currentLocaleLabel}
       >
         <LanguageIcon className="h-4 w-4 shrink-0" aria-hidden />
-        <span className="hidden sm:inline">{currentLocaleLabel}</span>
+        <span className="max-sm:hidden inline">{currentLocaleLabel}</span>
       </Button>
     </Dropdown>
   );

--- a/examples/next-seed/src/uikit/components-app/LogoutButton.tsx
+++ b/examples/next-seed/src/uikit/components-app/LogoutButton.tsx
@@ -51,7 +51,7 @@ export function LogoutButton(props: { showLabel?: boolean }) {
         <ArrowRightOnRectangleIcon
           className={showLabel ? 'h-4 w-4' : 'h-5 w-5'}
         />
-        {showLabel && <span className="hidden sm:inline">{tt.title}</span>}
+        {showLabel && <span className="max-sm:hidden inline">{tt.title}</span>}
       </Button>
     </Tooltip>
   );

--- a/examples/next-seed/src/uikit/components-app/RoutePageLayout.tsx
+++ b/examples/next-seed/src/uikit/components-app/RoutePageLayout.tsx
@@ -91,7 +91,7 @@ export function RoutePageLayout({
                 </LocaleLink>
               )}
               {headerSubtitle && (
-                <span className="hidden sm:inline text-sm text-secondary-text border-l border-primary-border pl-3 shrink-0">
+                <span className="max-sm:hidden inline text-sm text-secondary-text border-l border-primary-border pl-3 shrink-0">
                   {headerSubtitle}
                 </span>
               )}

--- a/examples/next-seed/src/uikit/components-pages/AdminLayout.tsx
+++ b/examples/next-seed/src/uikit/components-pages/AdminLayout.tsx
@@ -189,7 +189,7 @@ export function AdminLayout({
             <Button
               variant="ghost"
               size="sm"
-              className="hidden md:inline-flex"
+              className="max-md:hidden inline-flex"
               aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
               onClick={handleToggleDesktop}
             >
@@ -211,10 +211,10 @@ export function AdminLayout({
                 Admin
               </span>
             </LocaleLink>
-            <span className="bg-primary-border hidden h-4 w-px sm:block" />
+            <span className="bg-primary-border max-sm:hidden h-4 w-px block" />
             <span
               data-testid="admin-header-title"
-              className="text-secondary-text hidden truncate text-sm sm:inline"
+              className="text-secondary-text max-sm:hidden truncate text-sm inline"
             >
               {seoMetadata.title}
             </span>
@@ -232,7 +232,7 @@ export function AdminLayout({
         <aside
           data-testid="AdminLayoutSidebar"
           className={clsx(
-            'border-primary-border bg-secondary hidden h-full shrink-0 flex-col border-r transition-[width] duration-200 ease-out md:flex',
+            'border-primary-border bg-secondary max-md:hidden h-full shrink-0 flex-col border-r transition-[width] duration-200 ease-out flex',
             collapsed ? 'w-16' : 'w-56'
           )}
         >

--- a/examples/react-seed/src/pages/auth/Login.tsx
+++ b/examples/react-seed/src/pages/auth/Login.tsx
@@ -66,7 +66,7 @@ export default function LoginPage(_props: RouterRenderProps) {
       className="grid min-h-screen w-full lg:grid-cols-2"
     >
       <div
-        className="relative hidden overflow-hidden lg:block"
+        className="relative max-lg:hidden overflow-hidden block"
         style={{
           background:
             'linear-gradient(135deg, rgb(var(--color-brand) / 0.14) 0%, rgb(var(--color-brand) / 0.06) 40%, rgb(var(--color-brand) / 0.02) 100%)'

--- a/examples/react-seed/src/pages/auth/Register.tsx
+++ b/examples/react-seed/src/pages/auth/Register.tsx
@@ -68,7 +68,7 @@ export default function RegisterPage(_props: RouterRenderProps) {
       className="grid min-h-screen w-full lg:grid-cols-2"
     >
       <div
-        className="relative hidden overflow-hidden lg:block"
+        className="relative max-lg:hidden overflow-hidden block"
         style={{
           background:
             'linear-gradient(135deg, rgb(var(--color-brand) / 0.14) 0%, rgb(var(--color-brand) / 0.06) 40%, rgb(var(--color-brand) / 0.02) 100%)'


### PR DESCRIPTION
将 next-oauth、next-seed、react-seed 中响应式显隐从 hidden + 断点显示改为 max-*:hidden + 显式 display，条件显隐改用原生 hidden 属性。