### PR TITLE
fix(examples): 语言切换时保留 next-intl 动态路由 params

### DIFF
--- a/examples/next-oauth/src/uikit/components-app/LanguageSwitcher.tsx
+++ b/examples/next-oauth/src/uikit/components-app/LanguageSwitcher.tsx
@@ -3,6 +3,7 @@
 import { useMountedClient } from '@brain-toolkit/react-kit';
 import { LanguageIcon } from '@heroicons/react/24/outline';
 import { LocaleRouter } from '@qlover/corekit-bridge/url-helper';
+import { useParams } from 'next/navigation';
 import { useLocale } from 'next-intl';
 import { useCallback, useMemo, useTransition } from 'react';
 import { usePathname, useRouter } from '@/i18n/routing';
@@ -12,8 +13,30 @@ import { localeQueryParam, useLocaleRoutes } from '@config/common';
 import { i18nConfig } from '@config/i18n';
 import type { LocaleType } from '@config/i18n';
 
+/**
+ * Build dynamic route params for next-intl navigation (exclude `locale`).
+ *
+ * next-intl `usePathname()` returns templates like `/projects/[projectId]/general`;
+ * `router.replace(pathname, { locale })` alone would keep the literal `[projectId]`.
+ */
+function pathParamsFromNextParams(
+  params: ReturnType<typeof useParams>
+): Record<string, string | string[]> {
+  const pathParams: Record<string, string | string[]> = {};
+  for (const [key, raw] of Object.entries(
+    params as Record<string, string | string[]>
+  )) {
+    if (key === 'locale' || raw == null) {
+      continue;
+    }
+    pathParams[key] = raw;
+  }
+  return pathParams;
+}
+
 export function LanguageSwitcher() {
   const pathname = usePathname();
+  const params = useParams();
   const router = useRouter();
   const currentLocale = useLocale() as LocaleType;
   const [isPending, startTransition] = useTransition();
@@ -46,20 +69,31 @@ export function LanguageSwitcher() {
       if (!mounted || isPending || value === currentLocale) return;
 
       startTransition(() => {
-        const currentPath =
-          pathname + window.location.search + window.location.hash;
-
         if (useLocaleRoutes) {
-          router.replace(currentPath as '/', { locale: value });
+          const pathParams = pathParamsFromNextParams(params);
+          const query = Object.fromEntries(
+            new URLSearchParams(window.location.search)
+          );
+
+          router.replace(
+            {
+              pathname,
+              params: pathParams,
+              ...(Object.keys(query).length > 0 ? { query } : {})
+            } as never,
+            { locale: value }
+          );
           return;
         }
 
+        const currentPath =
+          pathname + window.location.search + window.location.hash;
         router.replace(
           localeRouter!.switchLocale(currentPath, currentLocale, value) as '/'
         );
       });
     },
-    [mounted, isPending, pathname, currentLocale, localeRouter, router]
+    [mounted, isPending, pathname, params, currentLocale, localeRouter, router]
   );
 
   const currentLocaleLabel =

--- a/examples/next-seed/src/uikit/components-app/LanguageSwitcher.tsx
+++ b/examples/next-seed/src/uikit/components-app/LanguageSwitcher.tsx
@@ -3,6 +3,7 @@
 import { useMountedClient } from '@brain-toolkit/react-kit';
 import { LanguageIcon } from '@heroicons/react/24/outline';
 import { LocaleRouter } from '@qlover/corekit-bridge/url-helper';
+import { useParams } from 'next/navigation';
 import { useLocale } from 'next-intl';
 import { useCallback, useMemo, useTransition } from 'react';
 import { usePathname, useRouter } from '@/i18n/routing';
@@ -12,8 +13,30 @@ import { localeQueryParam, useLocaleRoutes } from '@config/common';
 import { i18nConfig } from '@config/i18n';
 import type { LocaleType } from '@config/i18n';
 
+/**
+ * Build dynamic route params for next-intl navigation (exclude `locale`).
+ *
+ * next-intl `usePathname()` returns templates like `/projects/[projectId]/general`;
+ * `router.replace(pathname, { locale })` alone would keep the literal `[projectId]`.
+ */
+function pathParamsFromNextParams(
+  params: ReturnType<typeof useParams>
+): Record<string, string | string[]> {
+  const pathParams: Record<string, string | string[]> = {};
+  for (const [key, raw] of Object.entries(
+    params as Record<string, string | string[]>
+  )) {
+    if (key === 'locale' || raw == null) {
+      continue;
+    }
+    pathParams[key] = raw;
+  }
+  return pathParams;
+}
+
 export function LanguageSwitcher() {
   const pathname = usePathname();
+  const params = useParams();
   const router = useRouter();
   const currentLocale = useLocale() as LocaleType;
   const [isPending, startTransition] = useTransition();
@@ -46,20 +69,31 @@ export function LanguageSwitcher() {
       if (!mounted || isPending || value === currentLocale) return;
 
       startTransition(() => {
-        const currentPath =
-          pathname + window.location.search + window.location.hash;
-
         if (useLocaleRoutes) {
-          router.replace(currentPath as '/', { locale: value });
+          const pathParams = pathParamsFromNextParams(params);
+          const query = Object.fromEntries(
+            new URLSearchParams(window.location.search)
+          );
+
+          router.replace(
+            {
+              pathname,
+              params: pathParams,
+              ...(Object.keys(query).length > 0 ? { query } : {})
+            } as never,
+            { locale: value }
+          );
           return;
         }
 
+        const currentPath =
+          pathname + window.location.search + window.location.hash;
         router.replace(
           localeRouter!.switchLocale(currentPath, currentLocale, value) as '/'
         );
       });
     },
-    [mounted, isPending, pathname, currentLocale, localeRouter, router]
+    [mounted, isPending, pathname, params, currentLocale, localeRouter, router]
   );
 
   const currentLocaleLabel =


### PR DESCRIPTION
同步 brain-toolkit pam 修复：useLocaleRoutes 模式下切换语言不再把 pathname 模板中的 [param] 当作字面量跳转。