### PR TITLE
fix(vitest): 修复 next-kit 在 create-release-pr 下的测试失败

### DIFF
--- a/examples/next-oauth/package.json
+++ b/examples/next-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-oauth",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Next.js OAuth 2.0 authorization server example",
   "scripts": {

--- a/examples/next-seed/package.json
+++ b/examples/next-seed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-seed",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "description": "Next.js app shell with theme, i18n, and auth",
   "scripts": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlover/create-app",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Create a new app with a single command",
   "private": false,
   "type": "module",

--- a/packages/next-kit/package.json
+++ b/packages/next-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/next-kit",
   "description": "Shared Next.js app shell: isomorphic common layer, server runtime, and client runtime",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "private": false,
   "sideEffects": false,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,45 @@
 import { defineConfig } from 'vitest/config';
 import { resolve } from 'node:path';
 
+const packageAliases = {
+  '@qlover/code2markdown': resolve(__dirname, './packages/code2markdown/src'),
+  // Source lives under src/core; prefix alias also covers /ioc, /bootstrap, etc.
+  '@qlover/corekit-bridge/build/tw-root10px': resolve(
+    __dirname,
+    './packages/corekit-bridge/src/build/tw-root10px'
+  ),
+  '@qlover/corekit-bridge/build/vite-env-config': resolve(
+    __dirname,
+    './packages/corekit-bridge/src/build/vite-env-config'
+  ),
+  '@qlover/corekit-bridge/build/vite-ts-to-locales': resolve(
+    __dirname,
+    './packages/corekit-bridge/src/build/vite-ts-to-locales'
+  ),
+  '@qlover/corekit-bridge': resolve(
+    __dirname,
+    './packages/corekit-bridge/src/core'
+  ),
+  '@qlover/corekit-node': resolve(__dirname, './packages/corekit-node/src'),
+  '@qlover/create-app': resolve(__dirname, './packages/create-app/src'),
+  '@qlover/env-loader': resolve(__dirname, './packages/env-loader/src'),
+  '@qlover/eslint-plugin': resolve(__dirname, './packages/eslint-plugin/src'),
+  '@qlover/fe-corekit': resolve(__dirname, './packages/fe-corekit/src'),
+  '@qlover/fe-release': resolve(__dirname, './packages/fe-release/src'),
+  '@qlover/fe-scripts': resolve(__dirname, './packages/fe-scripts/src'),
+  '@qlover/fe-standard': resolve(__dirname, './packages/fe-standard'),
+  '@qlover/logger': resolve(__dirname, './packages/logger/src'),
+  '@qlover/scripts-context': resolve(
+    __dirname,
+    './packages/scripts-context/src'
+  ),
+  '@qlover/tailwind-theme': resolve(__dirname, './packages/tailwind-theme/src'),
+  '@qlover/tailwind-theme/generater': resolve(
+    __dirname,
+    './packages/tailwind-theme/src/generater.ts'
+  )
+};
+
 export default defineConfig({
   test: {
     projects: [
@@ -13,62 +52,24 @@ export default defineConfig({
           exclude: [
             '**/node_modules/**',
             '**/dist/**',
-            '**/packages/create-app/templates/**'
+            '**/packages/create-app/templates/**',
+            // React Testing Library hooks/components need jsdom (next-kit project)
+            'packages/next-kit/**'
           ]
         },
         resolve: {
-          alias: {
-            '@qlover/code2markdown': resolve(
-              __dirname,
-              './packages/code2markdown/src'
-            ),
-            '@qlover/corekit-bridge': resolve(
-              __dirname,
-              './packages/corekit-bridge/src'
-            ),
-            '@qlover/corekit-node': resolve(
-              __dirname,
-              './packages/corekit-node/src'
-            ),
-            '@qlover/create-app': resolve(
-              __dirname,
-              './packages/create-app/src'
-            ),
-            '@qlover/env-loader': resolve(
-              __dirname,
-              './packages/env-loader/src'
-            ),
-            '@qlover/eslint-plugin': resolve(
-              __dirname,
-              './packages/eslint-plugin/src'
-            ),
-            '@qlover/fe-corekit': resolve(
-              __dirname,
-              './packages/fe-corekit/src'
-            ),
-            '@qlover/fe-release': resolve(
-              __dirname,
-              './packages/fe-release/src'
-            ),
-            '@qlover/fe-scripts': resolve(
-              __dirname,
-              './packages/fe-scripts/src'
-            ),
-            '@qlover/fe-standard': resolve(__dirname, './packages/fe-standard'),
-            '@qlover/logger': resolve(__dirname, './packages/logger/src'),
-            '@qlover/scripts-context': resolve(
-              __dirname,
-              './packages/scripts-context/src'
-            ),
-            '@qlover/tailwind-theme': resolve(
-              __dirname,
-              './packages/tailwind-theme/src'
-            ),
-            '@qlover/tailwind-theme/generater': resolve(
-              __dirname,
-              './packages/tailwind-theme/src/generater.ts'
-            )
-          }
+          alias: packageAliases
+        }
+      },
+      {
+        test: {
+          name: 'next-kit',
+          environment: 'jsdom',
+          globals: true,
+          include: ['packages/next-kit/__tests__/**/*.test.{ts,tsx}']
+        },
+        resolve: {
+          alias: packageAliases
         }
       },
       './examples/*'


### PR DESCRIPTION
将 corekit-bridge 别名指向 src/core，并为 next-kit 启用 jsdom，避免 test:force 出现模块解析失败与 document is not defined。