### PR TITLE
chore: 接入 pamenv-cli 并修复 LocaleLink 语言链接

### DIFF
--- a/.cursor/rules/gitcommit.mdc
+++ b/.cursor/rules/gitcommit.mdc
@@ -1,15 +1,11 @@
 ---
-description: 
-globs: 
-alwaysApply: false
+description: Git commit message standards for this repo
+alwaysApply: true
 ---
-这个文档目前cursor还不支持自定义说明, 未来可能支持
-
-This document currently cursor does not support custom descriptions, which may be supported in the future.
 
 ## Git Commit Standards
 
-All commit messages must be in English
+All commit messages must be in English.
 
 ### Format
 
@@ -17,9 +13,16 @@ All commit messages must be in English
 type(scope?): subject
 
 body?
-
-footer?
 ```
+
+Do **not** add author attribution footers such as:
+
+- `Co-authored-by:`
+- `Signed-off-by:`
+- `Made-with: Cursor`
+- other tool/author trailers
+
+Keep the message to type/subject and optional body only (breaking-change / issue refs are OK if needed).
 
 ### Length Limits
 
@@ -43,7 +46,7 @@ footer?
 - Subject: Must be concise (max 50 chars), present tense, no period
 - Scope (Optional): Component name (e.g., auth, api)
 - Body (Optional): Wrap text at 72 chars, use bullet points for multiple items
-- Footer (Optional): Breaking changes, issues
+- Do not put file lists or author info in the footer
 
 ### Examples
 
@@ -52,7 +55,3 @@ feat(auth): implement google oauth login
 fix(api): fix session timeout issue
 docs: add installation steps
 ```
-
-### notes
-
-如果可以将修改的文件列表列在 Footer 中

--- a/examples/next-oauth/src/uikit/components/LocaleLink.tsx
+++ b/examples/next-oauth/src/uikit/components/LocaleLink.tsx
@@ -4,6 +4,7 @@ import {
   LocaleLink as KitLocaleLink,
   type LocaleLinkProps
 } from '@qlover/next-kit/client';
+import { useLocale } from 'next-intl';
 import { useLocaleRoutes } from '@config/common';
 import { i18nConfig } from '@config/i18n';
 
@@ -17,9 +18,12 @@ type AppLocaleLinkProps = Omit<
 
 /**
  * App LocaleLink — injects i18n / routing defaults from config.
+ * Uses current next-intl locale when `locale` prop is omitted.
  */
 export function LocaleLink(props: AppLocaleLinkProps) {
+  const currentLocale = useLocale();
   const {
+    locale = currentLocale,
     fallbackLocale = i18nConfig.fallbackLng,
     useLocaleRoutes: useLocaleRoutesProp = useLocaleRoutes,
     ...rest
@@ -28,6 +32,7 @@ export function LocaleLink(props: AppLocaleLinkProps) {
   return (
     <KitLocaleLink
       {...rest}
+      locale={locale}
       fallbackLocale={fallbackLocale}
       useLocaleRoutes={useLocaleRoutesProp}
     />

--- a/examples/next-seed/src/uikit/components/LocaleLink.tsx
+++ b/examples/next-seed/src/uikit/components/LocaleLink.tsx
@@ -4,6 +4,7 @@ import {
   LocaleLink as KitLocaleLink,
   type LocaleLinkProps
 } from '@qlover/next-kit/client';
+import { useLocale } from 'next-intl';
 import { useLocaleRoutes } from '@config/common';
 import { i18nConfig } from '@config/i18n';
 
@@ -17,9 +18,12 @@ type AppLocaleLinkProps = Omit<
 
 /**
  * App LocaleLink — injects i18n / routing defaults from config.
+ * Uses current next-intl locale when `locale` prop is omitted.
  */
 export function LocaleLink(props: AppLocaleLinkProps) {
+  const currentLocale = useLocale();
   const {
+    locale = currentLocale,
     fallbackLocale = i18nConfig.fallbackLng,
     useLocaleRoutes: useLocaleRoutesProp = useLocaleRoutes,
     ...rest
@@ -28,6 +32,7 @@ export function LocaleLink(props: AppLocaleLinkProps) {
   return (
     <KitLocaleLink
       {...rest}
+      locale={locale}
       fallbackLocale={fallbackLocale}
       useLocaleRoutes={useLocaleRoutesProp}
     />

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "check-packages": "fe-check-packages",
     "prepare": "husky",
     "type-check": "tsc --build --force && pnpm -r --filter \"./examples/**\" run type-check",
-    "version:patch": " pnpm -r exec npm version patch --no-git-tag-version"
+    "version:patch": " pnpm -r exec npm version patch --no-git-tag-version",
+    "env:pull": "pamenv pull fe-base -e local",
+    "env:push": "pamenv push fe-base -e local"
   },
   "keywords": [
     "fe",
@@ -88,6 +90,7 @@
     "husky": "^9.1.7",
     "nx": "^22.7.5",
     "nx-cloud": "^19.1.3",
+    "pamenv-cli": "^1.3.0",
     "prettier": "^3.5.3",
     "prettier-plugin-jsdoc": "^1.8.0",
     "rimraf": "^5.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       nx-cloud:
         specifier: ^19.1.3
         version: 19.1.3
+      pamenv-cli:
+        specifier: ^1.3.0
+        version: 1.3.0(@types/node@22.19.19)
       prettier:
         specifier: ^3.5.3
         version: 3.8.3
@@ -833,7 +836,7 @@ importers:
         version: 7.3.5(@types/node@24.13.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-mock:
         specifier: ^3.0.2
-        version: 3.0.2(esbuild@0.19.12)(mockjs@1.1.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 3.0.2(esbuild@0.28.1)(mockjs@1.1.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.5
         version: 6.1.1(typescript@6.0.3)(vite@7.3.5(@types/node@24.13.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
@@ -3857,9 +3860,22 @@ packages:
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/checkbox@4.3.2':
     resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3875,9 +3891,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/core@10.3.2':
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3893,9 +3927,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/expand@4.0.23':
     resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3911,13 +3963,35 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
 
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/input@4.3.1':
     resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3933,9 +4007,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/password@4.0.23':
     resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3951,9 +4043,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/rawlist@4.1.11':
     resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3969,6 +4079,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/select@4.4.2':
     resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
     engines: {node: '>=18'}
@@ -3978,9 +4097,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/type@3.0.10':
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -7972,6 +8109,10 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -9024,8 +9165,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -10936,6 +11086,10 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -11352,6 +11506,11 @@ packages:
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
+  pamenv-cli@1.3.0:
+    resolution: {integrity: sha512-ymMhusvuU9lpLqxUCMhtJPevU/XRruswFdsWjkhSKEOf02T2zSAUd/ZThQwQ4Kf4iYdTeKJVtksz/gU0R/8vQw==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
 
   param-case@2.1.1:
     resolution: {integrity: sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==}
@@ -16680,6 +16839,8 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
+  '@inquirer/ansi@2.0.7': {}
+
   '@inquirer/checkbox@4.3.2(@types/node@20.11.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -16700,6 +16861,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@inquirer/checkbox@5.2.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+
   '@inquirer/confirm@5.1.21(@types/node@20.11.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@20.11.5)
@@ -16713,6 +16883,13 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/confirm@6.1.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
 
   '@inquirer/core@10.3.2(@types/node@20.11.5)':
     dependencies:
@@ -16740,6 +16917,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@inquirer/core@11.2.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+
   '@inquirer/editor@4.2.23(@types/node@20.11.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@20.11.5)
@@ -16756,6 +16945,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@inquirer/editor@5.2.2(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/external-editor': 3.0.3(@types/node@22.19.19)
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+
   '@inquirer/expand@4.0.23(@types/node@20.11.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@20.11.5)
@@ -16771,6 +16968,13 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/expand@5.1.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
 
   '@inquirer/external-editor@1.0.3(@types/node@20.11.5)':
     dependencies:
@@ -16793,7 +16997,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@inquirer/external-editor@3.0.3(@types/node@22.19.19)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.19
+
   '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/figures@2.0.7': {}
 
   '@inquirer/input@4.3.1(@types/node@20.11.5)':
     dependencies:
@@ -16809,6 +17022,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@inquirer/input@5.1.2(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+
   '@inquirer/number@3.0.23(@types/node@20.11.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@20.11.5)
@@ -16822,6 +17042,13 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/number@4.1.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
 
   '@inquirer/password@4.0.23(@types/node@20.11.5)':
     dependencies:
@@ -16838,6 +17065,14 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/password@5.1.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
 
   '@inquirer/prompts@7.10.1(@types/node@20.11.5)':
     dependencies:
@@ -16869,6 +17104,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@inquirer/prompts@8.5.2(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@22.19.19)
+      '@inquirer/confirm': 6.1.1(@types/node@22.19.19)
+      '@inquirer/editor': 5.2.2(@types/node@22.19.19)
+      '@inquirer/expand': 5.1.1(@types/node@22.19.19)
+      '@inquirer/input': 5.1.2(@types/node@22.19.19)
+      '@inquirer/number': 4.1.1(@types/node@22.19.19)
+      '@inquirer/password': 5.1.1(@types/node@22.19.19)
+      '@inquirer/rawlist': 5.3.1(@types/node@22.19.19)
+      '@inquirer/search': 4.2.1(@types/node@22.19.19)
+      '@inquirer/select': 5.2.1(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+
   '@inquirer/rawlist@4.1.11(@types/node@20.11.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@20.11.5)
@@ -16884,6 +17134,13 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/rawlist@5.3.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
 
   '@inquirer/search@3.2.2(@types/node@20.11.5)':
     dependencies:
@@ -16902,6 +17159,14 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/search@4.2.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
 
   '@inquirer/select@4.4.2(@types/node@20.11.5)':
     dependencies:
@@ -16923,6 +17188,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@inquirer/select@5.2.1(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@22.19.19)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+
   '@inquirer/type@3.0.10(@types/node@20.11.5)':
     optionalDependencies:
       '@types/node': 20.11.5
@@ -16930,6 +17204,10 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@25.9.1)':
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@inquirer/type@4.0.7(@types/node@22.19.19)':
+    optionalDependencies:
+      '@types/node': 22.19.19
 
   '@inversifyjs/common@1.5.2': {}
 
@@ -21723,9 +22001,9 @@ snapshots:
       esbuild: 0.18.20
       load-tsconfig: 0.2.5
 
-  bundle-require@4.2.1(esbuild@0.19.12):
+  bundle-require@4.2.1(esbuild@0.28.1):
     dependencies:
-      esbuild: 0.19.12
+      esbuild: 0.28.1
       load-tsconfig: 0.2.5
 
   bundle-require@5.1.0(esbuild@0.27.7):
@@ -22067,6 +22345,8 @@ snapshots:
   commander@13.1.0: {}
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@2.20.3: {}
 
@@ -23627,7 +23907,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastest-levenshtein@1.0.16: {}
 
@@ -25662,6 +25952,8 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
+  mute-stream@3.0.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -26209,6 +26501,13 @@ snapshots:
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
+
+  pamenv-cli@1.3.0(@types/node@22.19.19):
+    dependencies:
+      '@inquirer/prompts': 8.5.2(@types/node@22.19.19)
+      commander: 15.0.0
+    transitivePeerDependencies:
+      - '@types/node'
 
   param-case@2.1.1:
     dependencies:
@@ -29188,13 +29487,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-mock@3.0.2(esbuild@0.19.12)(mockjs@1.1.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
+  vite-plugin-mock@3.0.2(esbuild@0.28.1)(mockjs@1.1.0)(vite@7.3.5(@types/node@24.13.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
-      bundle-require: 4.2.1(esbuild@0.19.12)
+      bundle-require: 4.2.1(esbuild@0.28.1)
       chokidar: 3.6.0
       connect: 3.7.0
       debug: 4.4.3
-      esbuild: 0.19.12
+      esbuild: 0.28.1
       fast-glob: 3.3.3
       mockjs: 1.1.0
       path-to-regexp: 6.3.0


### PR DESCRIPTION
## 摘要
- 接入 `pamenv-cli`，提供 `pnpm env:pull` / `pnpm env:push`，同步 PAM 项目 `fe-base` 的 `local` 环境
- 修复 next-oauth / next-seed 登录页 LocaleLink：未传 `locale` 时改用 `useLocale()`，避免中文界面链到 `/en/`
- 更新 `.cursor/rules/gitcommit.mdc`，禁止 commit 附带作者 footer（如 `Co-authored-by`）

## 测试计划
- [ ] 安装后 `pnpm exec pamenv --help` 正常
- [ ] `pamenv login` 后，`pnpm env:pull` / `pnpm env:push` 可同步 `fe-base` 的 `.env.local`
- [ ] 打开 `/zh/auth/login`：「在此创建」「OAuth 集成文档」「OAuth 测试台」链接为 `/zh/...`
- [ ] 打开 `/en/auth/login`：对应链接仍为 `/en/...`