### PR TITLE
Release @qlover/oauth-wrapper@0.7.0,examples/next-oauth@1.1.0

### DIFF
--- a/examples/next-oauth/CHANGELOG.md
+++ b/examples/next-oauth/CHANGELOG.md
@@ -1,5 +1,21 @@
 # examples/next-oauth
 
+## 1.1.0
+
+### Minor Changes
+
+#### ✨ Features
+
+- **next-oauth:** 接入本地身份并保留登录语言 ([8008fbc](https://github.com/qlover/fe-base/commit/8008fbcc558cc3bb06b5ce451d59475887ed546e)) ([#685](https://github.com/qlover/fe-base/pull/685))
+
+#### 🐞 Bug Fixes
+
+- **examples:** LocaleLink uses current locale ([8219c5a](https://github.com/qlover/fe-base/commit/8219c5a2a29e4c183b846b5202c8c468ee3a87ec)) ([#684](https://github.com/qlover/fe-base/pull/684))
+
+### Patch Changes
+
+- Update dependency **@qlover/oauth-wrapper** from `0.6.3` to `0.7.0`
+
 ## 1.0.0
 
 ### Major Changes

--- a/examples/next-oauth/package.json
+++ b/examples/next-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/next-oauth",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Next.js OAuth 2.0 authorization server example",
   "scripts": {

--- a/packages/oauth-wrapper/CHANGELOG.md
+++ b/packages/oauth-wrapper/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.0
+
+### Minor Changes
+
+#### ✨ Features
+
+- **oauth-wrapper:** 增加本地身份映射并 await 会话 ([b9b228e](https://github.com/qlover/fe-base/commit/b9b228ef65e730aa624f431c88164be13ba840a9)) ([#685](https://github.com/qlover/fe-base/pull/685))
+
+#### 🐞 Bug Fixes
+
+- **oauth-wrapper:** 修复 identity store 测试类型错误 ([0955288](https://github.com/qlover/fe-base/commit/0955288a019bab5490cdbe2bc066663ff05152a0)) ([#685](https://github.com/qlover/fe-base/pull/685))
+
 ## 0.6.3
 
 ### Patch Changes

--- a/packages/oauth-wrapper/package.json
+++ b/packages/oauth-wrapper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qlover/oauth-wrapper",
   "description": "Provider-agnostic OAuth 2.0 authorization server core (authorization code, PKCE, token exchange, userinfo)",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "type": "module",
   "private": false,
   "sideEffects": false,


### PR DESCRIPTION
## Changelog


### @qlover/oauth-wrapper@0.7.0

#### Minor Changes

#### ✨ Features

- **oauth-wrapper:** 增加本地身份映射并 await 会话 ([b9b228e](https://github.com/qlover/fe-base/commit/b9b228ef65e730aa624f431c88164be13ba840a9)) ([#685](https://github.com/qlover/fe-base/pull/685))
#### 🐞 Bug Fixes

- **oauth-wrapper:** 修复 identity store 测试类型错误 ([0955288](https://github.com/qlover/fe-base/commit/0955288a019bab5490cdbe2bc066663ff05152a0)) ([#685](https://github.com/qlover/fe-base/pull/685))


### examples/next-oauth@1.1.0

#### Minor Changes

#### ✨ Features

- **next-oauth:** 接入本地身份并保留登录语言 ([8008fbc](https://github.com/qlover/fe-base/commit/8008fbcc558cc3bb06b5ce451d59475887ed546e)) ([#685](https://github.com/qlover/fe-base/pull/685))
#### 🐞 Bug Fixes

- **examples:** LocaleLink uses current locale ([8219c5a](https://github.com/qlover/fe-base/commit/8219c5a2a29e4c183b846b5202c8c468ee3a87ec)) ([#684](https://github.com/qlover/fe-base/pull/684))
