### PR TITLE
fix(pam,brain-oauth): developer apps logo_uri、rotate-secret 405 与弹窗 UX

### DIFF
--- a/examples/next-oauth/server/repositorys/OAuthWrapperRepository.ts
+++ b/examples/next-oauth/server/repositorys/OAuthWrapperRepository.ts
@@ -322,6 +322,7 @@ export class OAuthWrapperRepository implements OAuthWrapperRepositoryInterface {
         client_secret_hash: clientSecretHash,
         client_name: input.client_name,
         client_uri: input.client_uri || null,
+        logo_uri: input.logo_uri || null,
         redirect_uris: input.redirect_uris,
         grant_types: ['authorization_code', 'refresh_token'],
         scopes: ['openid', 'profile', 'email'],
@@ -356,6 +357,7 @@ export class OAuthWrapperRepository implements OAuthWrapperRepositoryInterface {
       .update({
         client_name: input.client_name,
         client_uri: input.client_uri || null,
+        logo_uri: input.logo_uri || null,
         redirect_uris: input.redirect_uris,
         updated_at: new Date().toISOString()
       })

--- a/examples/next-oauth/shared/config/i18n-identifier/pages/page.developer.apps.ts
+++ b/examples/next-oauth/shared/config/i18n-identifier/pages/page.developer.apps.ts
@@ -110,6 +110,14 @@ export const DEVELOPER_APPS_APP_NAME_REQUIRED =
   'developer_apps:app_name_required';
 
 /**
+ * @description Redirect URIs required validation message
+ * @localZh 请至少填写一个重定向 URI
+ * @localEn Please enter at least one redirect URI
+ */
+export const DEVELOPER_APPS_REDIRECT_URIS_REQUIRED =
+  'developer_apps:redirect_uris_required';
+
+/**
  * @description Redirect URIs textarea placeholder
  * @localZh https://your-app.com/callback\nhttps://localhost:3000/callback
  * @localEn https://your-app.com/callback\nhttps://localhost:3000/callback
@@ -132,6 +140,28 @@ export const DEVELOPER_APPS_REDIRECT_URIS_HINT =
  */
 export const DEVELOPER_APPS_CLIENT_URI_LABEL =
   'developer_apps:client_uri_label';
+
+/**
+ * @description Logo URI form label
+ * @localZh Logo 图片 URL (可选)
+ * @localEn Logo image URL (Optional)
+ */
+export const DEVELOPER_APPS_LOGO_URI_LABEL = 'developer_apps:logo_uri_label';
+
+/**
+ * @description Logo URI form hint
+ * @localZh 填写可公开访问的图片地址，将显示在授权页与应用列表
+ * @localEn Public image URL shown on the consent screen and app list
+ */
+export const DEVELOPER_APPS_LOGO_URI_HINT = 'developer_apps:logo_uri_hint';
+
+/**
+ * @description Logo URI invalid message
+ * @localZh 请输入有效的图片 URL
+ * @localEn Please enter a valid image URL
+ */
+export const DEVELOPER_APPS_LOGO_URI_INVALID =
+  'developer_apps:logo_uri_invalid';
 
 /**
  * @description Cancel button text
@@ -295,6 +325,13 @@ export const DEVELOPER_APPS_COPY_SECRET_SUCCESS =
  * @localEn Loading applications…
  */
 export const DEVELOPER_APPS_LOADING = 'developer_apps:loading';
+
+/**
+ * @description Saving / submitting state label
+ * @localZh 保存中...
+ * @localEn Saving...
+ */
+export const DEVELOPER_APPS_SAVING = 'developer_apps:saving';
 
 /**
  * @description Link to OAuth flow playground

--- a/examples/next-oauth/shared/config/i18n-mapping/developerAppsI18n.ts
+++ b/examples/next-oauth/shared/config/i18n-mapping/developerAppsI18n.ts
@@ -30,10 +30,14 @@ export const developerAppsI18n = Object.freeze({
   // form fields
   appNameLabel: developerAppsKeys.DEVELOPER_APPS_APP_NAME_LABEL,
   appNameRequired: developerAppsKeys.DEVELOPER_APPS_APP_NAME_REQUIRED,
+  redirectUrisRequired: developerAppsKeys.DEVELOPER_APPS_REDIRECT_URIS_REQUIRED,
   redirectUrisPlaceholder:
     developerAppsKeys.DEVELOPER_APPS_REDIRECT_URIS_PLACEHOLDER,
   redirectUrisHint: developerAppsKeys.DEVELOPER_APPS_REDIRECT_URIS_HINT,
   clientUriLabel: developerAppsKeys.DEVELOPER_APPS_CLIENT_URI_LABEL,
+  logoUriLabel: developerAppsKeys.DEVELOPER_APPS_LOGO_URI_LABEL,
+  logoUriHint: developerAppsKeys.DEVELOPER_APPS_LOGO_URI_HINT,
+  logoUriInvalid: developerAppsKeys.DEVELOPER_APPS_LOGO_URI_INVALID,
 
   // buttons
   cancelButton: commonKeys.COMMON_CANCEL,
@@ -67,6 +71,7 @@ export const developerAppsI18n = Object.freeze({
   copyClientIdSuccess: developerAppsKeys.DEVELOPER_APPS_COPY_CLIENT_ID_SUCCESS,
   copySecretSuccess: developerAppsKeys.DEVELOPER_APPS_COPY_SECRET_SUCCESS,
   loading: developerAppsKeys.DEVELOPER_APPS_LOADING,
+  saving: developerAppsKeys.DEVELOPER_APPS_SAVING,
   playgroundLink: developerAppsKeys.DEVELOPER_APPS_PLAYGROUND_LINK,
   clientTypeLabel: developerAppsKeys.DEVELOPER_APPS_CLIENT_TYPE_LABEL,
   clientTypeConfidential:

--- a/examples/next-oauth/shared/config/route.ts
+++ b/examples/next-oauth/shared/config/route.ts
@@ -1,4 +1,4 @@
-import { API_CLIENTS_2 } from './apiRoutes';
+import { API_CLIENTS_2, API_CLIENTS_ROTATE_SECRET } from './apiRoutes';
 import { useLocaleRoutes } from './common';
 import { i18nConfig } from './i18n';
 import type { LocaleType } from './i18n';
@@ -178,7 +178,7 @@ export function apiClientDetail<T extends string>(
 }
 
 export function apiClientRotateSecret(clientId: string): string {
-  return apiClientDetail(clientId).replace(
+  return API_CLIENTS_ROTATE_SECRET.replace(
     ':clientId',
     encodeURIComponent(clientId)
   );

--- a/examples/next-oauth/src/uikit/components-app/developer/apps/DeveloperAppsPage.tsx
+++ b/examples/next-oauth/src/uikit/components-app/developer/apps/DeveloperAppsPage.tsx
@@ -16,6 +16,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type FormEvent
 } from 'react';
@@ -63,6 +64,47 @@ function parseRedirectUris(raw: string): string[] {
     .filter((uri) => uri.length > 0);
 }
 
+function AppListLogo({
+  name,
+  logoUri
+}: {
+  name: string;
+  logoUri?: string | null;
+}) {
+  const [broken, setBroken] = useState(false);
+  const initial = (name.trim().charAt(0) || '?').toUpperCase();
+  const src = logoUri?.trim();
+  const boxClass =
+    'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-primary-border bg-secondary text-sm font-semibold text-brand sm:h-9 sm:w-9';
+
+  useEffect(() => {
+    setBroken(false);
+  }, [src]);
+
+  if (!src || broken) {
+    return (
+      <div
+        data-testid="DeveloperAppsPageLogoFallback"
+        className={boxClass}
+        aria-hidden
+      >
+        {initial}
+      </div>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- external logo URL from developer input
+    <img
+      data-testid="DeveloperAppsPageLogo"
+      src={src}
+      alt=""
+      className="h-8 w-8 shrink-0 rounded-lg border border-primary-border object-cover bg-secondary sm:h-9 sm:w-9"
+      onError={() => setBroken(true)}
+    />
+  );
+}
+
 export interface DeveloperAppsPageProps {
   initialApps: OAuthClientListItem[];
 }
@@ -81,6 +123,9 @@ export function DeveloperAppsPageComponent({
   const [loading, setLoading] = useState(initialApps.length === 0);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
+  const [editDetailLoading, setEditDetailLoading] = useState(false);
+  const [createSubmitting, setCreateSubmitting] = useState(false);
+  const [editSubmitting, setEditSubmitting] = useState(false);
   const [editingApp, setEditingApp] = useState<OAuthClientListItem | null>(
     null
   );
@@ -100,12 +145,15 @@ export function DeveloperAppsPageComponent({
   const [editFieldErrors, setEditFieldErrors] = useState<
     Partial<Record<keyof OAuthClientFormValues, string>>
   >({});
+  const editLoadSeqRef = useRef(0);
 
   const formLabels = useMemo(
     () => ({
       appNameLabel: tt.appNameLabel || 'Application Name',
       appNameRequired: tt.appNameRequired || 'Please enter application name',
       redirectUrisLabel: tt.redirectUrisLabel || 'Redirect URIs (one per line)',
+      redirectUrisRequired:
+        tt.redirectUrisRequired || 'Please enter at least one redirect URI',
       redirectUrisPlaceholder:
         tt.redirectUrisPlaceholder ||
         'https://your-app.com/callback\nhttps://localhost:3000/callback',
@@ -114,6 +162,11 @@ export function DeveloperAppsPageComponent({
         'Multiple callback URLs supported, one per line. Must use HTTPS (http://localhost allowed for local development).',
       clientUriLabel:
         tt.clientUriLabel || 'Application Homepage URL (Optional)',
+      logoUriLabel: tt.logoUriLabel || 'Logo image URL (Optional)',
+      logoUriHint:
+        tt.logoUriHint ||
+        'Public image URL shown on the consent screen and app list',
+      logoUriInvalid: tt.logoUriInvalid || 'Please enter a valid image URL',
       clientTypeLabel: tt.clientTypeLabel || 'Client type',
       clientTypeConfidential:
         tt.clientTypeConfidential || 'Confidential (client_secret)',
@@ -145,7 +198,15 @@ export function DeveloperAppsPageComponent({
       errors.client_name = formLabels.appNameRequired;
     }
     if (parseRedirectUris(values.redirect_uris).length === 0) {
-      errors.redirect_uris = formLabels.appNameRequired;
+      errors.redirect_uris = formLabels.redirectUrisRequired;
+    }
+    const logoUri = values.logo_uri.trim();
+    if (logoUri) {
+      try {
+        new URL(logoUri);
+      } catch {
+        errors.logo_uri = formLabels.logoUriInvalid;
+      }
     }
     return Object.keys(errors).length > 0 ? errors : null;
   };
@@ -213,21 +274,25 @@ export function DeveloperAppsPageComponent({
 
   const handleCreateApp = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (createSubmitting) return;
     const validationErrors = validateFormValues(createValues);
     if (validationErrors) {
       setCreateFieldErrors(validationErrors);
       return;
     }
     setCreateFieldErrors({});
+    setCreateSubmitting(true);
 
     try {
       const redirectUris = parseRedirectUris(createValues.redirect_uris);
-      const payload: OAuthClientCreate = {
+      const logoUri = createValues.logo_uri.trim();
+      const payload = {
         client_name: createValues.client_name.trim(),
         client_uri: createValues.client_uri.trim() || undefined,
+        logo_uri: logoUri || undefined,
         redirect_uris: redirectUris,
         confidential: createValues.confidential
-      };
+      } satisfies OAuthClientCreate & { logo_uri?: string };
 
       const response = await fetch(API_CLIENTS, {
         method: 'POST',
@@ -246,6 +311,7 @@ export function DeveloperAppsPageComponent({
         client_id: data.client_id,
         client_name: data.client_name,
         client_uri: data.client_uri,
+        logo_uri: logoUri || null,
         redirect_uris: data.redirect_uris,
         confidential: data.confidential,
         created_at: data.created_at,
@@ -266,12 +332,14 @@ export function DeveloperAppsPageComponent({
       dialogHandler.error(
         tt.toastError || 'Operation failed, please try again later'
       );
+    } finally {
+      setCreateSubmitting(false);
     }
   };
 
   const handleEditApp = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!editingApp) return;
+    if (!editingApp || editSubmitting || editDetailLoading) return;
 
     const validationErrors = validateFormValues(editValues);
     if (validationErrors) {
@@ -279,14 +347,17 @@ export function DeveloperAppsPageComponent({
       return;
     }
     setEditFieldErrors({});
+    setEditSubmitting(true);
 
     try {
       const redirectUris = parseRedirectUris(editValues.redirect_uris);
-      const payload: OAuthClientUpdate = {
+      const logoUri = editValues.logo_uri.trim();
+      const payload = {
         client_name: editValues.client_name.trim(),
         client_uri: editValues.client_uri.trim() || undefined,
+        logo_uri: logoUri || '',
         redirect_uris: redirectUris
-      };
+      } satisfies OAuthClientUpdate & { logo_uri?: string };
 
       const response = await fetch(apiClientDetail(editingApp.client_id), {
         method: 'PUT',
@@ -308,6 +379,7 @@ export function DeveloperAppsPageComponent({
                 ...app,
                 client_name: updatedApp.client_name,
                 client_uri: updatedApp.client_uri,
+                logo_uri: (updatedApp.logo_uri ?? logoUri) || null,
                 redirect_uris: updatedApp.redirect_uris,
                 updated_at: updatedApp.updated_at
               }
@@ -327,6 +399,8 @@ export function DeveloperAppsPageComponent({
       dialogHandler.error(
         tt.toastError || 'Operation failed, please try again later'
       );
+    } finally {
+      setEditSubmitting(false);
     }
   };
 
@@ -396,6 +470,13 @@ export function DeveloperAppsPageComponent({
           }
 
           setApps((prev) => prev.filter((app) => app.client_id !== clientId));
+          if (editingApp?.client_id === clientId) {
+            editLoadSeqRef.current += 1;
+            setEditModalVisible(false);
+            setEditingApp(null);
+            setEditDetailLoading(false);
+            resetEditForm();
+          }
           dialogHandler.success(tt.toastDeleteSuccess || 'Application deleted');
         } catch (error) {
           console.error('Delete app error:', error);
@@ -409,35 +490,69 @@ export function DeveloperAppsPageComponent({
   };
 
   const openEditModal = (app: OAuthClientListItem) => {
+    const loadSeq = ++editLoadSeqRef.current;
     setEditingApp(app);
+    setEditFieldErrors({});
+    setEditSubmitting(false);
+    setEditDetailLoading(true);
+    setEditValues({
+      client_name: app.client_name,
+      client_uri: app.client_uri || '',
+      logo_uri: app.logo_uri || '',
+      redirect_uris: app.redirect_uris.join('\n'),
+      confidential: app.confidential ?? true
+    });
+    setEditModalVisible(true);
+
     void (async () => {
       try {
-        const detail = await readAppApiJson<OAuthClientDetail>(
-          await fetch(apiClientDetail(app.client_id), {
-            credentials: 'include'
-          })
-        );
+        const detailResponse = await fetch(apiClientDetail(app.client_id), {
+          credentials: 'include'
+        });
+        if (!detailResponse.ok) {
+          throw new Error('Failed to load application detail');
+        }
+        const detail = await readAppApiJson<OAuthClientDetail>(detailResponse);
+        if (loadSeq !== editLoadSeqRef.current) return;
         setEditValues({
           client_name: detail.client_name,
           client_uri: detail.client_uri || '',
+          logo_uri: detail.logo_uri || '',
           redirect_uris: detail.redirect_uris.join('\n'),
           confidential: detail.confidential
         });
-      } catch {
-        setEditValues({
-          client_name: app.client_name,
-          client_uri: app.client_uri || '',
-          redirect_uris: app.redirect_uris.join('\n'),
-          confidential: app.confidential ?? true
-        });
+      } catch (error) {
+        if (loadSeq !== editLoadSeqRef.current) return;
+        console.error('Load edit detail error:', error);
+        dialogHandler.error(
+          tt.toastError || 'Operation failed, please try again later'
+        );
+      } finally {
+        if (loadSeq === editLoadSeqRef.current) {
+          setEditDetailLoading(false);
+        }
       }
     })();
-    setEditFieldErrors({});
-    setEditModalVisible(true);
+  };
+
+  const closeCreateModal = () => {
+    if (createSubmitting) return;
+    setCreateModalVisible(false);
+    resetCreateForm();
+  };
+
+  const closeEditModal = () => {
+    if (editSubmitting) return;
+    editLoadSeqRef.current += 1;
+    setEditModalVisible(false);
+    setEditingApp(null);
+    setEditDetailLoading(false);
+    resetEditForm();
   };
 
   const openCreateModal = () => {
     resetCreateForm();
+    setCreateSubmitting(false);
     setCreateModalVisible(true);
   };
 
@@ -508,6 +623,10 @@ export function DeveloperAppsPageComponent({
                       <div className="flex flex-wrap justify-between items-start gap-4">
                         <div className="flex-1 min-w-0 space-y-2">
                           <div className="flex items-center gap-2 flex-wrap">
+                            <AppListLogo
+                              name={app.client_name}
+                              logoUri={app.logo_uri}
+                            />
                             <h2 className="text-lg font-semibold text-primary-text">
                               {app.client_name}
                             </h2>
@@ -524,6 +643,18 @@ export function DeveloperAppsPageComponent({
                                 : tt.statusPublic || 'Public'}
                             </span>
                           </div>
+                          {app.client_uri ? (
+                            <p className="text-sm">
+                              <a
+                                href={app.client_uri}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-brand hover:underline break-all"
+                              >
+                                {app.client_uri}
+                              </a>
+                            </p>
+                          ) : null}
                           <div className="flex items-center gap-2 flex-wrap min-w-0">
                             <code className="text-sm bg-secondary text-primary-text px-2 py-1 rounded-lg font-mono border border-primary-border/40 break-all">
                               {tt.clientIdLabel || 'Client ID'}: {app.client_id}
@@ -623,24 +754,30 @@ export function DeveloperAppsPageComponent({
       <DeveloperOverlayModal
         open={createModalVisible}
         title={tt.createModalTitle || 'Create OAuth Application'}
-        onClose={() => {
-          setCreateModalVisible(false);
-          resetCreateForm();
-        }}
+        onClose={closeCreateModal}
+        closeOnBackdrop={!createSubmitting}
         maxWidthClass="max-w-xl"
         footer={
           <div className="flex justify-end gap-3">
             <Button
               variant="secondary"
-              onClick={() => {
-                setCreateModalVisible(false);
-                resetCreateForm();
-              }}
+              onClick={closeCreateModal}
+              disabled={createSubmitting}
             >
               {tt.cancelButton || 'Cancel'}
             </Button>
-            <Button type="submit" form="create-oauth-client" variant="primary">
-              {tt.createSubmitButton || 'Create Application'}
+            <Button
+              type="submit"
+              form="create-oauth-client"
+              variant="primary"
+              disabled={createSubmitting}
+            >
+              {createSubmitting ? (
+                <ArrowPathIcon className="h-4 w-4 animate-spin" />
+              ) : null}
+              {createSubmitting
+                ? tt.saving || 'Saving...'
+                : tt.createSubmitButton || 'Create Application'}
             </Button>
           </div>
         }
@@ -650,6 +787,7 @@ export function DeveloperAppsPageComponent({
           values={createValues}
           fieldErrors={createFieldErrors}
           labels={formLabels}
+          disabled={createSubmitting}
           onChange={(patch) => {
             setCreateValues((prev) => ({ ...prev, ...patch }));
             setCreateFieldErrors((prev) => {
@@ -670,85 +808,109 @@ export function DeveloperAppsPageComponent({
       <DeveloperOverlayModal
         open={editModalVisible}
         title={tt.editModalTitle || 'Edit Application'}
-        onClose={() => {
-          setEditModalVisible(false);
-          setEditingApp(null);
-          resetEditForm();
-        }}
+        onClose={closeEditModal}
+        closeOnBackdrop={!editSubmitting && !editDetailLoading}
         maxWidthClass="max-w-xl"
         footer={
-          <div className="flex flex-wrap gap-3 justify-between items-center">
-            <div className="flex flex-wrap gap-2">
-              {editingApp && (
-                <>
-                  <Button
-                    variant="warning"
-                    onClick={() =>
-                      void handleRotateSecret(
-                        editingApp.client_id,
-                        editValues.confidential
-                      )
-                    }
-                    disabled={!editValues.confidential}
-                  >
-                    <KeyIcon className="h-4 w-4" />
+          <div className="flex items-center gap-2">
+            {editingApp ? (
+              <div className="flex shrink-0 gap-1.5">
+                <Button
+                  variant="warning"
+                  className="h-9 px-2.5"
+                  onClick={() =>
+                    handleRotateSecret(
+                      editingApp.client_id,
+                      editValues.confidential
+                    )
+                  }
+                  disabled={
+                    !editValues.confidential ||
+                    editDetailLoading ||
+                    editSubmitting
+                  }
+                  title={tt.rotateSecretButton || 'Rotate Secret'}
+                  aria-label={tt.rotateSecretButton || 'Rotate Secret'}
+                >
+                  <KeyIcon className="h-4 w-4" />
+                  <span className="hidden sm:inline">
                     {tt.rotateSecretButton || 'Rotate Secret'}
-                  </Button>
-                  <Button
-                    variant="danger"
-                    onClick={() => {
-                      const clientId = editingApp.client_id;
-                      setEditModalVisible(false);
-                      setEditingApp(null);
-                      resetEditForm();
-                      handleDeleteApp(clientId);
-                    }}
-                  >
-                    <TrashIcon className="h-4 w-4" />
+                  </span>
+                </Button>
+                <Button
+                  variant="danger"
+                  className="h-9 px-2.5"
+                  onClick={() => handleDeleteApp(editingApp.client_id)}
+                  disabled={editDetailLoading || editSubmitting}
+                  title={tt.deleteButton || 'Delete'}
+                  aria-label={tt.deleteButton || 'Delete'}
+                >
+                  <TrashIcon className="h-4 w-4" />
+                  <span className="hidden sm:inline">
                     {tt.deleteButton || 'Delete'}
-                  </Button>
-                </>
-              )}
-            </div>
-            <div className="flex gap-3">
+                  </span>
+                </Button>
+              </div>
+            ) : null}
+            <div className="ml-auto flex items-center gap-3">
               <Button
                 variant="secondary"
-                onClick={() => {
-                  setEditModalVisible(false);
-                  setEditingApp(null);
-                  resetEditForm();
-                }}
+                onClick={closeEditModal}
+                disabled={editSubmitting}
               >
                 {tt.cancelButton || 'Cancel'}
               </Button>
-              <Button type="submit" form="edit-oauth-client" variant="primary">
-                {tt.saveSubmitButton || 'Save Changes'}
+              <Button
+                type="submit"
+                form="edit-oauth-client"
+                variant="primary"
+                disabled={editDetailLoading || editSubmitting}
+              >
+                {editSubmitting || editDetailLoading ? (
+                  <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                ) : null}
+                {editSubmitting
+                  ? tt.saving || 'Saving...'
+                  : editDetailLoading
+                    ? tt.loading || 'Loading...'
+                    : tt.saveSubmitButton || 'Save Changes'}
               </Button>
             </div>
           </div>
         }
       >
-        <OAuthClientAppForm
-          formId="edit-oauth-client"
-          values={editValues}
-          fieldErrors={editFieldErrors}
-          labels={formLabels}
-          lockClientType
-          onChange={(patch) => {
-            setEditValues((prev) => ({ ...prev, ...patch }));
-            setEditFieldErrors((prev) => {
-              const next = { ...prev };
-              for (const key of Object.keys(
-                patch
-              ) as (keyof OAuthClientFormValues)[]) {
-                delete next[key];
-              }
-              return next;
-            });
-          }}
-          onSubmit={handleEditApp}
-          footer={null}
-        />
+        {editDetailLoading ? (
+          <div
+            data-testid="DeveloperAppsEditLoading"
+            className="flex flex-col items-center justify-center gap-3 py-10 text-secondary-text"
+          >
+            <ArrowPathIcon className="h-8 w-8 animate-spin text-brand" />
+            <span className="text-sm">{tt.loading || 'Loading...'}</span>
+          </div>
+        ) : (
+          <OAuthClientAppForm
+            formId="edit-oauth-client"
+            values={editValues}
+            fieldErrors={editFieldErrors}
+            labels={formLabels}
+            lockClientType
+            disabled={editSubmitting}
+            onChange={(patch) => {
+              setEditValues((prev) => ({ ...prev, ...patch }));
+              setEditFieldErrors((prev) => {
+                const next = { ...prev };
+                for (const key of Object.keys(
+                  patch
+                ) as (keyof OAuthClientFormValues)[]) {
+                  delete next[key];
+                }
+                return next;
+              });
+            }}
+            onSubmit={handleEditApp}
+            footer={null}
+          />
+        )}
       </DeveloperOverlayModal>
     </>
   );

--- a/examples/next-oauth/src/uikit/components-app/developer/apps/OAuthClientAppForm.tsx
+++ b/examples/next-oauth/src/uikit/components-app/developer/apps/OAuthClientAppForm.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { clsx } from 'clsx';
+import { useState, type FormEvent, type ReactNode } from 'react';
 import { oauthInputClass, oauthLabelClass } from '@config/component';
-import type { FormEvent, ReactNode } from 'react';
 
 export type OAuthClientFormValues = {
   client_name: string;
   redirect_uris: string;
   client_uri: string;
+  logo_uri: string;
   /** `true` = confidential; `false` = public (PKCE, no secret). Immutable after create. */
   confidential: boolean;
 };
@@ -15,10 +17,13 @@ export const emptyOAuthClientFormValues: OAuthClientFormValues = {
   client_name: '',
   redirect_uris: '',
   client_uri: '',
+  logo_uri: '',
   confidential: true
 };
 
-const textareaClass = `${oauthInputClass} resize-y min-h-[5.5rem]`;
+const textareaClass = `${oauthInputClass} resize-y min-h-[4.5rem] sm:min-h-[5.5rem]`;
+const radioClass =
+  'mt-0.5 h-4 w-4 shrink-0 accent-[#7c3aed] border-primary-border';
 
 export interface OAuthClientAppFormLabels {
   appNameLabel: string;
@@ -27,11 +32,38 @@ export interface OAuthClientAppFormLabels {
   redirectUrisPlaceholder: string;
   redirectUrisHint: string;
   clientUriLabel: string;
+  logoUriLabel: string;
+  logoUriHint: string;
+  logoUriInvalid: string;
   clientTypeLabel: string;
   clientTypeConfidential: string;
   clientTypePublic: string;
   clientTypeHint: string;
   clientTypeLockedHint?: string;
+}
+
+function LogoPreview({ src, alt }: { src: string; alt: string }) {
+  const [broken, setBroken] = useState(false);
+  if (!src || broken) {
+    return (
+      <div
+        data-testid="OAuthClientAppFormLogoPlaceholder"
+        className="flex h-12 w-12 items-center justify-center rounded-xl border border-dashed border-primary-border bg-secondary text-xs text-secondary-text"
+      >
+        —
+      </div>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- external logo URL from developer input
+    <img
+      data-testid="OAuthClientAppFormLogoPreview"
+      src={src}
+      alt={alt}
+      className="h-12 w-12 rounded-xl border border-primary-border object-cover bg-secondary"
+      onError={() => setBroken(true)}
+    />
+  );
 }
 
 export function OAuthClientAppForm(props: {
@@ -44,6 +76,8 @@ export function OAuthClientAppForm(props: {
   footer?: ReactNode | null;
   /** When true, client type cannot be changed (edit mode). */
   lockClientType?: boolean;
+  /** Disable all inputs (e.g. while submitting). */
+  disabled?: boolean;
 }) {
   const {
     formId,
@@ -53,50 +87,72 @@ export function OAuthClientAppForm(props: {
     onChange,
     onSubmit,
     footer,
-    lockClientType = false
+    lockClientType = false,
+    disabled = false
   } = props;
+
+  const logoPreviewSrc = values.logo_uri.trim();
+  const fieldsDisabled = disabled;
 
   return (
     <form
       data-testid="OAuthClientAppForm"
       id={formId}
       onSubmit={onSubmit}
-      className="space-y-4"
+      className="space-y-3 sm:space-y-4"
       noValidate
     >
       <div>
         <p className={oauthLabelClass}>{labels.clientTypeLabel}</p>
-        <div className="flex flex-col sm:flex-row gap-3 mt-1">
-          <label className="flex items-start gap-2 text-sm text-primary-text cursor-pointer">
+        <div className="mt-1.5 flex flex-col gap-2 sm:flex-row sm:gap-3">
+          <label
+            className={clsx(
+              'flex items-start gap-2.5 rounded-lg border px-3 py-2 text-sm text-primary-text',
+              values.confidential
+                ? 'border-[#7c3aed]/40 bg-[#7c3aed]/5'
+                : 'border-primary-border bg-secondary/40',
+              fieldsDisabled || lockClientType
+                ? 'cursor-default opacity-80'
+                : 'cursor-pointer'
+            )}
+          >
             <input
               type="radio"
               name={`${formId}-confidential`}
               checked={values.confidential}
-              disabled={lockClientType}
+              disabled={lockClientType || fieldsDisabled}
               onChange={() => onChange({ confidential: true })}
-              className="mt-1"
+              className={radioClass}
             />
-            <span>
-              <span className="font-medium">
-                {labels.clientTypeConfidential}
-              </span>
+            <span className="font-medium leading-snug">
+              {labels.clientTypeConfidential}
             </span>
           </label>
-          <label className="flex items-start gap-2 text-sm text-primary-text cursor-pointer">
+          <label
+            className={clsx(
+              'flex items-start gap-2.5 rounded-lg border px-3 py-2 text-sm text-primary-text',
+              !values.confidential
+                ? 'border-[#7c3aed]/40 bg-[#7c3aed]/5'
+                : 'border-primary-border bg-secondary/40',
+              fieldsDisabled || lockClientType
+                ? 'cursor-default opacity-80'
+                : 'cursor-pointer'
+            )}
+          >
             <input
               type="radio"
               name={`${formId}-confidential`}
               checked={!values.confidential}
-              disabled={lockClientType}
+              disabled={lockClientType || fieldsDisabled}
               onChange={() => onChange({ confidential: false })}
-              className="mt-1"
+              className={radioClass}
             />
-            <span>
-              <span className="font-medium">{labels.clientTypePublic}</span>
+            <span className="font-medium leading-snug">
+              {labels.clientTypePublic}
             </span>
           </label>
         </div>
-        <p className="text-xs text-secondary-text mt-1">
+        <p className="mt-1.5 text-xs leading-relaxed text-secondary-text">
           {lockClientType
             ? (labels.clientTypeLockedHint ?? labels.clientTypeHint)
             : labels.clientTypeHint}
@@ -105,13 +161,15 @@ export function OAuthClientAppForm(props: {
 
       <div>
         <label htmlFor={`${formId}-client_name`} className={oauthLabelClass}>
-          {labels.appNameLabel} <span className="text-red-500">*</span>
+          {labels.appNameLabel}{' '}
+          <span className="text-(--fe-color-error)">*</span>
         </label>
         <input
           id={`${formId}-client_name`}
           name="client_name"
           type="text"
           required
+          disabled={fieldsDisabled}
           value={values.client_name}
           onChange={(e) => onChange({ client_name: e.target.value })}
           placeholder="My Application"
@@ -124,7 +182,7 @@ export function OAuthClientAppForm(props: {
         {fieldErrors.client_name && (
           <p
             id={`${formId}-client_name-error`}
-            className="text-red-500 mt-1 text-sm"
+            className="text-(--fe-color-error) mt-1 text-sm"
             role="alert"
           >
             {fieldErrors.client_name}
@@ -134,13 +192,15 @@ export function OAuthClientAppForm(props: {
 
       <div>
         <label htmlFor={`${formId}-redirect_uris`} className={oauthLabelClass}>
-          {labels.redirectUrisLabel} <span className="text-red-500">*</span>
+          {labels.redirectUrisLabel}{' '}
+          <span className="text-(--fe-color-error)">*</span>
         </label>
         <textarea
           id={`${formId}-redirect_uris`}
           name="redirect_uris"
           required
           rows={3}
+          disabled={fieldsDisabled}
           value={values.redirect_uris}
           onChange={(e) => onChange({ redirect_uris: e.target.value })}
           placeholder={labels.redirectUrisPlaceholder}
@@ -155,7 +215,7 @@ export function OAuthClientAppForm(props: {
         {fieldErrors.redirect_uris ? (
           <p
             id={`${formId}-redirect_uris-error`}
-            className="text-red-500 mt-1 text-sm"
+            className="text-(--fe-color-error) mt-1 text-sm"
             role="alert"
           >
             {fieldErrors.redirect_uris}
@@ -178,6 +238,7 @@ export function OAuthClientAppForm(props: {
           id={`${formId}-client_uri`}
           name="client_uri"
           type="url"
+          disabled={fieldsDisabled}
           value={values.client_uri}
           onChange={(e) => onChange({ client_uri: e.target.value })}
           placeholder="https://your-app.com"
@@ -185,10 +246,49 @@ export function OAuthClientAppForm(props: {
           aria-invalid={!!fieldErrors.client_uri}
         />
         {fieldErrors.client_uri && (
-          <p className="text-red-500 mt-1 text-sm" role="alert">
+          <p className="text-(--fe-color-error) mt-1 text-sm" role="alert">
             {fieldErrors.client_uri}
           </p>
         )}
+      </div>
+
+      <div>
+        <label htmlFor={`${formId}-logo_uri`} className={oauthLabelClass}>
+          {labels.logoUriLabel}
+        </label>
+        <div className="mt-1 flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
+          <LogoPreview
+            key={logoPreviewSrc}
+            src={logoPreviewSrc}
+            alt={values.client_name || 'App logo'}
+          />
+          <div className="min-w-0 flex-1">
+            <input
+              id={`${formId}-logo_uri`}
+              name="logo_uri"
+              type="url"
+              disabled={fieldsDisabled}
+              value={values.logo_uri}
+              onChange={(e) => onChange({ logo_uri: e.target.value })}
+              placeholder="https://your-app.com/logo.png"
+              className={oauthInputClass}
+              aria-invalid={!!fieldErrors.logo_uri}
+              aria-describedby={`${formId}-logo_uri-hint`}
+            />
+            {fieldErrors.logo_uri ? (
+              <p className="text-(--fe-color-error) mt-1 text-sm" role="alert">
+                {fieldErrors.logo_uri}
+              </p>
+            ) : (
+              <p
+                id={`${formId}-logo_uri-hint`}
+                className="mt-1 text-xs leading-relaxed text-secondary-text"
+              >
+                {labels.logoUriHint}
+              </p>
+            )}
+          </div>
+        </div>
       </div>
 
       {footer ?? null}

--- a/packages/oauth-wrapper/src/core/schema/OAuthAuthorizeSchema.ts
+++ b/packages/oauth-wrapper/src/core/schema/OAuthAuthorizeSchema.ts
@@ -71,6 +71,7 @@ export type OAuthClientDetail = z.infer<typeof OAuthClientDetailSchema>;
 export const OAuthClientCreateSchema = z.object({
   client_name: z.string().min(1).max(100),
   client_uri: z.string().url().optional().or(z.literal('')),
+  logo_uri: z.string().url().optional().or(z.literal('')),
   redirect_uris: z.array(oauthRedirectUriSchema).min(1),
   /** `true` = confidential (client_secret); `false` = public (PKCE required). */
   confidential: z.boolean().default(true)
@@ -81,6 +82,7 @@ export type OAuthClientCreate = z.infer<typeof OAuthClientCreateSchema>;
 export const OAuthClientUpdateSchema = z.object({
   client_name: z.string().min(1).max(100),
   client_uri: z.string().url().optional().or(z.literal('')),
+  logo_uri: z.string().url().optional().or(z.literal('')),
   redirect_uris: z.array(oauthRedirectUriSchema).min(1)
 });
 


### PR DESCRIPTION
## Summary
- 修复 `apiClientRotateSecret` URL 拼错导致重置密钥 **405**
- create/update 支持 `logo_uri` 落库；表单预览 + 列表头像/主页链接
- 编辑弹窗 sheet/单行底栏、加载态与校验文案修复

## Test plan
- [ ] 重置密钥不再 405
- [ ] logo 创建/编辑/列表展示与清除
- [ ] 移动端编辑底栏可用；空 redirect 校验文案正确